### PR TITLE
fix: bump SGLang version to 0.5.14

### DIFF
--- a/docker/justfile
+++ b/docker/justfile
@@ -1,5 +1,5 @@
 BACKEND := env("BACKEND", "sglang")
-SGLANG_VERSION := env("SGLANG_VERSION", "v0.5.8.post1")
+SGLANG_VERSION := env("SGLANG_VERSION", "v0.5.14")
 VLLM_VERSION := env("VLLM_VERSION", "v0.22.1")
 IMAGE_REPO := env("IMAGE_REPO", "ghcr.io/torchspec-project/torchspec")
 IMAGE_TAG := env("IMAGE_TAG", "")

--- a/docker/sglang/v0.5.14/Dockerfile
+++ b/docker/sglang/v0.5.14/Dockerfile
@@ -1,0 +1,28 @@
+ARG SGLANG_IMAGE=lmsysorg/sglang:v0.5.14-cu130
+FROM ${SGLANG_IMAGE} AS sglang
+
+WORKDIR /root/
+
+COPY patches/sglang/v0.5.14/sglang.patch /sgl-workspace/
+RUN cd /sgl-workspace/sglang && \
+    git apply --3way /sgl-workspace/sglang.patch && \
+    rm /sgl-workspace/sglang.patch && \
+    cd python && pip install -e .
+
+COPY . /root/torchspec
+RUN cd /root/torchspec && pip install --no-cache-dir -e ".[fa]"
+
+# TorchSpec's dependency pulls the generic CUDA 12 Mooncake wheel. Replace it
+# with the CUDA 13 wheel that matches this image family.
+RUN pip uninstall -y mooncake-transfer-engine || true && \
+    pip install --no-cache-dir --no-deps --force-reinstall \
+        mooncake-transfer-engine-cuda13==0.3.11.post1
+
+RUN chmod 755 /usr/local/lib/python3.12/dist-packages/mooncake/mooncake_master || true
+RUN if [ -f /usr/local/lib/python3.12/dist-packages/mooncake/cli.py ]; then \
+      sed -i 's/os.chmod(bin_path, 0o755)/pass/' /usr/local/lib/python3.12/dist-packages/mooncake/cli.py; \
+    fi
+
+RUN python3 -c "from sglang.srt.server_args import ServerArgs; from sglang.srt.speculative.spec_training_info import SpecTrainingInfo; assert 'enable_spec_training_mooncake' in ServerArgs.__dataclass_fields__; assert 'enable_aux_hidden_states' in ServerArgs.__dataclass_fields__"
+
+WORKDIR /root/torchspec

--- a/examples/qwen3-8b-single-node/run.sh
+++ b/examples/qwen3-8b-single-node/run.sh
@@ -56,6 +56,11 @@ echo "Local IP: $LOCAL_IP"
 echo "Extra args: $*"
 echo "=============================================="
 
+if [[ "$TOTAL_GPUS" -lt $((TRAIN_GPUS + INFERENCE_GPUS)) ]]; then
+    echo "Error: Not enough GPUs available. Total GPUs: $TOTAL_GPUS, Required: $((TRAIN_GPUS + INFERENCE_GPUS))"
+    exit 1
+fi
+
 # TODO: unify tp_size config across sglang/vllm backends
 python3 -m torchspec.train_entry \
     --config "$CONFIG_FILE" \

--- a/patches/sglang/v0.5.14/sglang.patch
+++ b/patches/sglang/v0.5.14/sglang.patch
@@ -1,0 +1,1056 @@
+torchspec sglang patch (base: 4289f36ef9)
+---
+ python/sglang/srt/entrypoints/engine.py            |   8 ++
+ python/sglang/srt/entrypoints/http_server.py       |  17 +++
+ python/sglang/srt/layers/logits_processor.py       |  54 +++++++++
+ python/sglang/srt/managers/detokenizer_manager.py  |   3 +
+ python/sglang/srt/managers/io_struct.py            |  48 ++++++++
+ python/sglang/srt/managers/schedule_batch.py       |  48 ++++++++
+ python/sglang/srt/managers/scheduler.py            |  60 +++++++++-
+ .../scheduler_components/batch_result_processor.py | 129 ++++++++++++++++++---
+ .../scheduler_components/output_streamer.py        |  51 +++++++-
+ python/sglang/srt/managers/tokenizer_manager.py    |  14 +++
+ .../srt/model_executor/forward_batch_info.py       |   7 +-
+ python/sglang/srt/model_executor/model_runner.py   |  15 +++
+ python/sglang/srt/models/qwen3_next.py             |   8 ++
+ python/sglang/srt/models/qwen3_next_mtp.py         |   3 +
+ python/sglang/srt/server_args.py                   |  23 ++++
+ .../sglang/srt/speculative/spec_training_info.py   |  50 ++++++++
+ 16 files changed, 520 insertions(+), 18 deletions(-)
+
+diff --git a/python/sglang/srt/entrypoints/engine.py b/python/sglang/srt/entrypoints/engine.py
+index d14e3d15cf..a165ad7552 100644
+--- a/python/sglang/srt/entrypoints/engine.py
++++ b/python/sglang/srt/entrypoints/engine.py
+@@ -349,6 +349,8 @@ class Engine(EngineScoreMixin, EngineBase):
+         rid: Optional[Union[List[str], str]] = None,
+         session_params: Optional[Dict] = None,
+         priority: Optional[int] = None,
++        spec_training_data_id: Optional[Union[List[str], str]] = None,
++        packed_loss_mask: Optional[Union[List[str], str]] = None,
+     ) -> Union[Dict, Iterator[Dict]]:
+         """
+         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
+@@ -386,6 +388,8 @@ class Engine(EngineScoreMixin, EngineBase):
+             rid=rid,
+             session_params=session_params,
+             priority=priority,
++            spec_training_data_id=spec_training_data_id,
++            packed_loss_mask=packed_loss_mask,
+         )
+         generator = self.tokenizer_manager.generate_request(obj, None)
+ 
+@@ -451,6 +455,8 @@ class Engine(EngineScoreMixin, EngineBase):
+         rid: Optional[Union[List[str], str]] = None,
+         session_params: Optional[Dict] = None,
+         priority: Optional[int] = None,
++        spec_training_data_id: Optional[Union[List[str], str]] = None,
++        packed_loss_mask: Optional[Union[List[str], str]] = None,
+     ) -> Union[Dict, AsyncIterator[Dict]]:
+         """
+         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
+@@ -488,6 +494,8 @@ class Engine(EngineScoreMixin, EngineBase):
+             rid=rid,
+             session_params=session_params,
+             priority=priority,
++            spec_training_data_id=spec_training_data_id,
++            packed_loss_mask=packed_loss_mask,
+         )
+         generator = self.tokenizer_manager.generate_request(obj, None)
+ 
+diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
+index 8f7722311a..410b835f07 100644
+--- a/python/sglang/srt/entrypoints/http_server.py
++++ b/python/sglang/srt/entrypoints/http_server.py
+@@ -812,6 +812,23 @@ async def generate_request(obj: GenerateReqInput, request: Request):
+             return _create_error_response(e)
+ 
+ 
++@app.api_route("/generate_for_spec_training", methods=["POST", "PUT"])
++async def generate_for_spec_training(obj: GenerateReqInput, request: Request):
++    """Handle a speculative training data collection request.
++
++    This endpoint reuses the generate flow but expects spec_training_data_id
++    and packed_loss_mask to be set.
++    """
++    try:
++        ret = await _global_state.tokenizer_manager.generate_request(
++            obj, request
++        ).__anext__()
++        return ret
++    except ValueError as e:
++        logger.error(f"[http_server] Error: {e}")
++        return _create_error_response(e)
++
++
+ @app.api_route("/encode", methods=["POST", "PUT"])
+ async def encode_request(obj: EmbeddingReqInput, request: Request):
+     """Handle an embedding request."""
+diff --git a/python/sglang/srt/layers/logits_processor.py b/python/sglang/srt/layers/logits_processor.py
+index a99d252677..76c4227f06 100644
+--- a/python/sglang/srt/layers/logits_processor.py
++++ b/python/sglang/srt/layers/logits_processor.py
+@@ -129,6 +129,10 @@ class LogitsProcessorOutput:
+ 
+     mm_input_embeds: Optional[torch.Tensor] = None
+ 
++    ## Part 6: Spec training - skip sampling and use these fake token ids
++    skip_sampling_next_token_ids: Optional[torch.Tensor] = None
++    last_hidden_states: Optional[torch.Tensor] = None
++
+ 
+ @dataclasses.dataclass
+ class LogitsMetadata:
+@@ -171,6 +175,9 @@ class LogitsMetadata:
+ 
+     mm_input_embeds: Optional[torch.Tensor] = None
+ 
++    # For spec training
++    has_spec_training: bool = False
++
+     @classmethod
+     def from_forward_batch(cls, forward_batch: ForwardBatch):
+         if (
+@@ -222,6 +229,7 @@ class LogitsMetadata:
+             global_num_tokens_for_logprob_gpu=forward_batch.global_num_tokens_for_logprob_gpu,
+             dp_padding_mode=DpPaddingMode.SUM_LEN,
+             mm_input_embeds=forward_batch.mm_input_embeds,
++            has_spec_training=forward_batch.has_spec_training,
+         )
+ 
+     def compute_dp_attention_metadata(self):
+@@ -336,6 +344,11 @@ class LogitsProcessor(nn.Module):
+         if logits_metadata.forward_mode.is_dllm_extend():
+             return self._get_dllm_logits(hidden_states, lm_head, logits_metadata)
+ 
++        last_hidden_states = None
++        if logits_metadata.has_spec_training:
++            assert hidden_states_before_norm is None
++            last_hidden_states = hidden_states
++
+         # Get the last hidden states and last logits for the next token prediction
+         (
+             pruned_states,
+@@ -363,6 +376,46 @@ class LogitsProcessor(nn.Module):
+         )
+         del hidden_states
+ 
++        # TODO(ywang): Support finegrained control over requests instead of
++        # forcing all requests to be spec training requests
++
++        # For offline spec training (prefill-only, no decode), skip sampling
++        # and return fake EOS. In decode mode with EAGLE, the eagle_worker
++        # sets has_spec_training=False so this block is not triggered.
++        if (
++            logits_metadata.has_spec_training
++            and logits_metadata.forward_mode.is_extend()
++        ):
++            if logits_metadata.extend_seq_lens is not None:
++                num_seqs = len(logits_metadata.extend_seq_lens)
++            elif input_ids is not None:
++                num_seqs = input_ids.shape[0]
++            else:
++                num_seqs = 1
++            eos_token_id = getattr(self.config, "eos_token_id", 0)
++            if isinstance(eos_token_id, list):
++                eos_token_id = eos_token_id[0]
++            if input_ids is not None:
++                device = input_ids.device
++            elif isinstance(last_hidden_states, torch.Tensor):
++                device = last_hidden_states.device
++            elif isinstance(last_hidden_states, tuple):
++                device = last_hidden_states[0].device
++            else:
++                device = lm_head.weight.device
++            fake_next_token_ids = torch.full(
++                (num_seqs,),
++                eos_token_id,
++                dtype=torch.long,
++                device=device,
++            )
++            return LogitsProcessorOutput(
++                next_token_logits=None,
++                hidden_states=hidden_states_to_store,
++                last_hidden_states=last_hidden_states,
++                skip_sampling_next_token_ids=fake_next_token_ids,
++            )
++
+         if not logits_metadata.extend_return_logprob:
+             # Compute logits for both input and sampled tokens.
+             logits = self._get_logits(pruned_states, lm_head, logits_metadata)
+@@ -438,6 +491,7 @@ class LogitsProcessor(nn.Module):
+             logits_metadata.forward_mode.is_decode_or_idle()
+             or logits_metadata.forward_mode.is_target_verify()
+             or logits_metadata.forward_mode.is_draft_extend_v2()
++            or logits_metadata.has_spec_training
+         ):
+             pruned_states = hidden_states
+             pruned_states_before_norm = hidden_states_before_norm
+diff --git a/python/sglang/srt/managers/detokenizer_manager.py b/python/sglang/srt/managers/detokenizer_manager.py
+index b05334deaa..dec5793dcb 100644
+--- a/python/sglang/srt/managers/detokenizer_manager.py
++++ b/python/sglang/srt/managers/detokenizer_manager.py
+@@ -450,6 +450,9 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+             token_steps=recv_obj.token_steps,
+             dp_ranks=recv_obj.dp_ranks,
+             time_stats=recv_obj.time_stats,
++            spec_training_data_ids=recv_obj.spec_training_data_ids,
++            packed_loss_masks=recv_obj.packed_loss_masks,
++            spec_training_mooncake_store_keys=recv_obj.spec_training_mooncake_store_keys,
+         )
+ 
+     def handle_freeze_gc_req(self, recv_req: FreezeGCReq):
+diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
+index 951f35495e..85912bf1fe 100644
+--- a/python/sglang/srt/managers/io_struct.py
++++ b/python/sglang/srt/managers/io_struct.py
+@@ -284,6 +284,13 @@ class GenerateReqInput(BaseReq):
+     # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].
+     multi_item_delimiter_indices: Optional[Union[List[List[int]], List[int]]] = None
+ 
++    # Speculative training fields
++    spec_training_data_id: Optional[Union[List[str], str]] = None
++    packed_loss_mask: Optional[Union[List[str], str]] = None
++
++    def is_spec_training_request(self) -> bool:
++        return self.spec_training_data_id is not None
++
+     def contains_mm_input(self) -> bool:
+         return (
+             has_valid_data(self.image_data)
+@@ -430,6 +437,7 @@ class GenerateReqInput(BaseReq):
+         self._normalize_custom_logit_processor(num)
+         self._normalize_extra_key(num)
+         self._normalize_bootstrap_params(num)
++        self._normalize_spec_training_params(num)
+ 
+     def _expand_inputs(self, num):
+         """Expand the main inputs (text, input_ids, input_embeds) for parallel sampling."""
+@@ -647,6 +655,24 @@ class GenerateReqInput(BaseReq):
+         elif isinstance(self.bootstrap_pair_key, list):
+             self.bootstrap_pair_key = self.bootstrap_pair_key * self.parallel_sample_num
+ 
++    def _normalize_spec_training_params(self, num):
++        """Normalize speculative training parameters for batch processing."""
++        if self.spec_training_data_id is None:
++            self.spec_training_data_id = [None] * num
++        elif not isinstance(self.spec_training_data_id, list):
++            self.spec_training_data_id = [self.spec_training_data_id] * num
++        elif isinstance(self.spec_training_data_id, list):
++            self.spec_training_data_id = (
++                self.spec_training_data_id * self.parallel_sample_num
++            )
++
++        if self.packed_loss_mask is None:
++            self.packed_loss_mask = [None] * num
++        elif not isinstance(self.packed_loss_mask, list):
++            self.packed_loss_mask = [self.packed_loss_mask] * num
++        elif isinstance(self.packed_loss_mask, list):
++            self.packed_loss_mask = self.packed_loss_mask * self.parallel_sample_num
++
+     def _validate_session_params(self):
+         """Validate that session parameters are properly formatted."""
+         if self.session_params is not None:
+@@ -738,6 +764,14 @@ class GenerateReqInput(BaseReq):
+             external_trace_header=self.external_trace_header,
+             http_worker_ipc=self.http_worker_ipc,
+             received_time=self.received_time,
++            spec_training_data_id=(
++                self.spec_training_data_id[i]
++                if self.spec_training_data_id is not None
++                else None
++            ),
++            packed_loss_mask=(
++                self.packed_loss_mask[i] if self.packed_loss_mask is not None else None
++            ),
+             multi_item_delimiter_indices=(
+                 self.multi_item_delimiter_indices[i]
+                 if self.multi_item_delimiter_indices is not None
+@@ -842,6 +876,10 @@ class TokenizedGenerateReqInput(BaseReq):
+     # Pre-computed delimiter indices for multi-item scoring
+     multi_item_delimiter_indices: Optional[List[int]] = None
+ 
++    # Speculative training fields
++    spec_training_data_id: Optional[str] = None
++    packed_loss_mask: Optional[str] = None
++
+     # For observability
+     time_stats: Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]] = None
+ 
+@@ -1186,6 +1224,11 @@ class BatchTokenIDOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
+     # DP rank of the scheduler that processed each request
+     dp_ranks: Optional[List[int]] = None
+ 
++    # Speculative training fields
++    spec_training_data_ids: Optional[List[str]] = None
++    packed_loss_masks: Optional[List[str]] = None
++    spec_training_mooncake_store_keys: Optional[List[List[str]]] = None
++
+     # For observability
+     time_stats: Optional[List[SchedulerReqTimeStats]] = None
+ 
+@@ -1254,6 +1297,11 @@ class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
+     # DP rank of the scheduler that processed each request
+     dp_ranks: Optional[List[int]] = None
+ 
++    # Speculative training fields
++    spec_training_data_ids: Optional[List[str]] = None
++    packed_loss_masks: Optional[List[str]] = None
++    spec_training_mooncake_store_keys: Optional[List[List[str]]] = None
++
+     # For observability
+     time_stats: Optional[List[SchedulerReqTimeStats]] = None
+ 
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index f1dc81d174..6727334dbd 100755
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -109,6 +109,7 @@ from sglang.srt.observability.req_time_stats import (
+ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+ from sglang.srt.sampling.sampling_params import SamplingParams
+ from sglang.srt.server_args import ServerArgs, get_global_server_args
++from sglang.srt.speculative.spec_training_info import SpecTrainingInfo
+ from sglang.srt.utils import flatten_nested_list
+ from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
+ 
+@@ -708,6 +709,8 @@ class Req(ReqDllmMixin):
+         ] = None,
+         return_pooled_hidden_states: bool = False,
+         multi_item_delimiter_indices: Optional[List[int]] = None,
++        spec_training_data_id: Optional[str] = None,
++        packed_loss_mask: Optional[str] = None,
+     ):
+         # Input and output info
+         self.rid = rid
+@@ -756,6 +759,11 @@ class Req(ReqDllmMixin):
+         # For multi-http worker
+         self.http_worker_ipc = http_worker_ipc
+ 
++        # Spec training fields
++        self.spec_training_data_id = spec_training_data_id
++        self.packed_loss_mask = packed_loss_mask
++        self.spec_training_mooncake_store_keys: List[str] = []
++
+         # Require reasoning for the request
+         self.require_reasoning = require_reasoning
+ 
+@@ -1839,6 +1847,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     capture_hidden_mode: Optional[CaptureHiddenMode] = None
+     return_hidden_states_before_norm: bool = False
+ 
++    # Spec Training
++    spec_training_info: Optional[SpecTrainingInfo] = None
++
+     @classmethod
+     def init_new(
+         cls,
+@@ -1854,6 +1865,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     ):
+         return_logprob = any(req.return_logprob for req in reqs)
+ 
++        spec_training_info = SpecTrainingInfo()
++        for req in reqs:
++            if req.spec_training_data_id is not None:
++                spec_training_info.add_request(
++                    rid=req.rid,
++                    data_id=req.spec_training_data_id,
++                    packed_loss_mask=req.packed_loss_mask,
++                )
++
+         batch = cls(
+             reqs=reqs,
+             req_to_token_pool=req_to_token_pool,
+@@ -1873,6 +1893,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+                 model_config.vocab_size,
+             ),
+             dllm_config=dllm_config,
++            spec_training_info=(
++                spec_training_info if not spec_training_info.is_empty() else None
++            ),
+         )
+         return batch
+ 
+@@ -2758,6 +2781,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+                 has_been_filtered=False,
+             )
+ 
++        if self.spec_training_info is not None:
++            kept_rids = {req.rid for req in self.reqs}
++            rids_to_remove = [
++                rid for rid in self.spec_training_info.data_ids if rid not in kept_rids
++            ]
++            for rid in rids_to_remove:
++                self.spec_training_info.remove_request(rid)
++            if self.spec_training_info.is_empty():
++                self.spec_training_info = None
++
+     def merge_batch(self, other: ScheduleBatch):
+         # Penalizer orchestrator must be merged before Batch.reqs is merged. This is because
+         # orchestrator.merge() depends on Batch.reqs during preparation of each penalizers, so it
+@@ -2816,6 +2849,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+         if self.spec_info:
+             self.spec_info.merge_batch(other.spec_info)
+ 
++        if self.spec_training_info is not None or other.spec_training_info is not None:
++            if self.spec_training_info is None:
++                self.spec_training_info = SpecTrainingInfo()
++            if other.spec_training_info is not None:
++                self.spec_training_info.data_ids.update(
++                    other.spec_training_info.data_ids
++                )
++                self.spec_training_info.packed_loss_masks.update(
++                    other.spec_training_info.packed_loss_masks
++                )
++                self.spec_training_info.mooncake_store_keys.update(
++                    other.spec_training_info.mooncake_store_keys
++                )
++
+     def copy(self):
+         # Only contain fields that will be used by process_batch_result.
+         # Shallow-copy the reqs list so that in-place mutations (filter_batch,
+@@ -2847,6 +2894,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             prefill_stats=self.prefill_stats,
+             fpm_start_time=self.fpm_start_time,
+             forward_iter=self.forward_iter,
++            spec_training_info=self.spec_training_info,
+         )
+ 
+     def maybe_evict_swa(self):
+diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
+index abba37441d..08be618baa 100644
+--- a/python/sglang/srt/managers/scheduler.py
++++ b/python/sglang/srt/managers/scheduler.py
+@@ -432,6 +432,26 @@ class Scheduler(
+         # so patching them afterwards is a no-op.
+         maybe_revert_pr_fix()
+ 
++        # Start mooncake store init in background (overlaps with model loading)
++        self._mooncake_init_thread = None
++        self._mooncake_init_error = None
++        self.eagle_mooncake_store = None
++        if self.server_args.enable_spec_training_mooncake and self.ps.attn_tp_rank == 0:
++            import threading
++
++            mooncake_device = torch.device(f"cuda:{self.ps.gpu_id}")
++
++            def _init_mooncake():
++                try:
++                    self.init_eagle_mooncake_store(device=mooncake_device)
++                except Exception as e:
++                    self._mooncake_init_error = e
++
++            self._mooncake_init_thread = threading.Thread(
++                target=_init_mooncake, daemon=True
++            )
++            self._mooncake_init_thread.start()
++
+         # Launch a model worker and draft model worker if using speculative decoding
+         self.init_model_worker()
+ 
+@@ -576,6 +596,12 @@ class Scheduler(
+ 
+         self.init_batch_result_processor()
+ 
++        # Wait for background mooncake store init to complete
++        if self._mooncake_init_thread is not None:
++            self._mooncake_init_thread.join()
++            if self._mooncake_init_error is not None:
++                raise self._mooncake_init_error
++
+         self.is_initializing = False
+ 
+     def init_zbal_on_npu(self):
+@@ -975,6 +1001,25 @@ class Scheduler(
+         self.forward_sleep_time = None
+         self._engine_paused = False
+ 
++    def init_eagle_mooncake_store(self, device=None):
++        if self.server_args.enable_spec_training_mooncake:
++            try:
++                from torchspec.transfer.mooncake import (
++                    EagleMooncakeStore,
++                    MooncakeConfig,
++                )
++
++                config = MooncakeConfig.from_env()
++                store = EagleMooncakeStore(config)
++                store.setup(device=device or self.device)
++                store.warmup_rdma()
++                self.eagle_mooncake_store = store
++                logger.info("EagleMooncakeStore initialized for spec training")
++            except ImportError:
++                logger.warning(
++                    "torchspec.mooncake not found. Spec training mooncake store disabled."
++                )
++
+     def init_chunked_prefill(self):
+         self.chunked_prefill_size = self.server_args.chunked_prefill_size
+         uses_transformers_backend = (
+@@ -1823,6 +1868,7 @@ class Scheduler(
+             spec_algorithm=self.spec_algorithm,
+             disaggregation_mode=self.disaggregation_mode,
+             enable_hicache_storage=lambda: self.enable_hicache_storage,
++            get_eagle_mooncake_store=lambda: self.eagle_mooncake_store,
+         )
+ 
+     def init_batch_result_processor(self) -> None:
+@@ -1847,6 +1893,8 @@ class Scheduler(
+             ),
+             output_streamer=self.output_streamer,
+             abort_request=self.abort_request,
++            attn_tp_rank=self.ps.attn_tp_rank,
++            get_eagle_mooncake_store=lambda: self.eagle_mooncake_store,
+         )
+ 
+     def init_req_max_new_tokens(self, req):
+@@ -2054,6 +2102,8 @@ class Scheduler(
+                 dllm_config=self.dllm_config,
+                 time_stats=recv_req.time_stats,
+                 multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
++                spec_training_data_id=recv_req.spec_training_data_id,
++                packed_loss_mask=recv_req.packed_loss_mask,
+             )
+             req.tokenizer = self.tokenizer
+ 
+@@ -3219,7 +3269,10 @@ class Scheduler(
+                             self.future_map.stash(future_indices, stash_payload)
+                             batch_result.copy_to_cpu(
+                                 return_logprob=batch.return_logprob,
+-                                return_hidden_states=batch.return_hidden_states,
++                                return_hidden_states=(
++                                    batch.return_hidden_states
++                                    and batch.spec_training_info is None
++                                ),
+                             )
+                         else:
+                             batch_result.future_indices = future_indices
+@@ -3350,7 +3403,10 @@ class Scheduler(
+             )
+             batch_result.copy_to_cpu(
+                 return_logprob=self.cur_batch.return_logprob,
+-                return_hidden_states=self.cur_batch.return_hidden_states,
++                return_hidden_states=(
++                    self.cur_batch.return_hidden_states
++                    and self.cur_batch.spec_training_info is None
++                ),
+             )
+ 
+         # Release the closure and large GPU tensors that are no longer needed.
+diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+index a9d5f0c28b..568a8ca7f6 100644
+--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
++++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+@@ -4,6 +4,7 @@ import logging
+ from dataclasses import dataclass
+ from typing import (
+     TYPE_CHECKING,
++    Any,
+     Callable,
+     List,
+     Optional,
+@@ -78,6 +79,10 @@ class SchedulerBatchResultProcessor:
+     logprob_result_processor: SchedulerLogprobResultProcessor
+     output_streamer: SchedulerOutputStreamer
+     abort_request: Callable
++    # Spec training: attn TP rank + lazy getter for the (background-initialized)
++    # EagleMooncakeStore living on the Scheduler.
++    attn_tp_rank: int
++    get_eagle_mooncake_store: Callable[[], Any]
+ 
+     def process_batch_result_prebuilt(self, batch: ScheduleBatch):
+         assert self.disaggregation_mode == DisaggregationMode.DECODE
+@@ -256,12 +261,20 @@ class SchedulerBatchResultProcessor:
+                             logprob_pt=logprob_pt,
+                         )
+ 
+-                    if (
+-                        req.return_hidden_states
+-                        and logits_output.hidden_states is not None
+-                    ):
++                    should_process_hidden_states = (
++                        logits_output.hidden_states is not None
++                        and (
++                            req.return_hidden_states
++                            or (
++                                req.spec_training_data_id is not None
++                                and self.attn_tp_rank == 0
++                            )
++                        )
++                    )
++                    if should_process_hidden_states:
+                         hidden_state_offset = self._append_prefill_hidden_states(
+                             req=req,
++                            batch=batch,
+                             logits_output=logits_output,
+                             hidden_state_offset=hidden_state_offset,
+                         )
+@@ -466,21 +479,109 @@ class SchedulerBatchResultProcessor:
+         self,
+         *,
+         req: Req,
++        batch: ScheduleBatch,
+         logits_output: LogitsProcessorOutput,
+         hidden_state_offset: int,
+     ) -> int:
+-        req.hidden_states.append(
+-            logits_output.hidden_states[
+-                hidden_state_offset : (
+-                    hidden_state_offset := hidden_state_offset
+-                    + len(req.origin_input_ids)
+-                )
++        """Process hidden states during prefill for spec training or
++        return_hidden_states. For spec training requests routed through the
++        EagleMooncakeStore, the hidden states are transferred via RDMA instead
++        of being copied back to the host. copy_done is already synchronized at
++        the top of process_batch_result_prefill, so the slice is safe to read.
++        """
++        seq_len = len(req.origin_input_ids)
++        req_hidden_states = logits_output.hidden_states[
++            hidden_state_offset : hidden_state_offset + seq_len
++        ]
++
++        store = self.get_eagle_mooncake_store()
++        if (
++            batch.spec_training_info is not None
++            and batch.spec_training_info.has_request(req.rid)
++            and store is not None
++        ):
++            self._send_hidden_states_to_mooncake(
++                req=req,
++                batch=batch,
++                hidden_states=req_hidden_states,
++                logits_output=logits_output,
++                hidden_state_offset=hidden_state_offset,
++            )
++        else:
++            req.hidden_states.append(req_hidden_states.cpu().clone().tolist())
++
++        return hidden_state_offset + seq_len
++
++    def _put_spec_training_mooncake(
++        self,
++        *,
++        key: str,
++        hidden_states: torch.Tensor,
++        input_ids: torch.Tensor,
++        last_hidden_states: Optional[torch.Tensor],
++    ):
++        import os
++
++        store = self.get_eagle_mooncake_store()
++        if os.getenv("TORCHSPEC_USP_SHARDED_MOONCAKE") == "1":
++            max_seq_raw = os.environ.get("TORCHSPEC_USP_MAX_SEQ_LENGTH")
++            store.put_usp_shards(
++                key=key,
++                hidden_states=hidden_states,
++                input_ids=input_ids,
++                last_hidden_states=last_hidden_states,
++                target=None,
++                sp_size=int(os.environ["TORCHSPEC_USP_SP_SIZE"]),
++                sp_ring_size=int(os.environ.get("TORCHSPEC_USP_RING_SIZE", "1")),
++                ttt_length=int(os.environ.get("TORCHSPEC_USP_TTT_LENGTH", "1")),
++                max_seq_length=int(max_seq_raw) if max_seq_raw else None,
++            )
++            return
++
++        store.put(
++            key=key,
++            hidden_states=hidden_states,
++            input_ids=input_ids,
++            last_hidden_states=last_hidden_states,
++        )
++
++    def _send_hidden_states_to_mooncake(
++        self,
++        *,
++        req: Req,
++        batch: ScheduleBatch,
++        hidden_states: torch.Tensor,
++        logits_output: LogitsProcessorOutput,
++        hidden_state_offset: int,
++    ):
++        import uuid
++
++        data_id = batch.spec_training_info.data_ids.get(req.rid, req.rid)
++        key = f"{data_id}_{uuid.uuid4().hex[:8]}"
++
++        seq_len = hidden_states.shape[0]
++        input_ids = torch.tensor(
++            req.origin_input_ids, dtype=torch.long, device=hidden_states.device
++        )
++
++        last_hidden_states = None
++        store_lhs = getattr(
++            self.server_args, "spec_training_store_last_hidden_states", True
++        )
++        if store_lhs and logits_output.last_hidden_states is not None:
++            last_hidden_states = logits_output.last_hidden_states[
++                hidden_state_offset : hidden_state_offset + seq_len
+             ]
+-            .cpu()
+-            .clone()
+-            .tolist()
++
++        self._put_spec_training_mooncake(
++            key=key,
++            hidden_states=hidden_states,
++            input_ids=input_ids,
++            last_hidden_states=last_hidden_states,
+         )
+-        return hidden_state_offset
++
++        req.spec_training_mooncake_store_keys.append(key)
++        batch.spec_training_info.mooncake_store_keys[data_id].append(key)
+ 
+     def _apply_prefill_grammar(self, *, req: Req, next_token_id: int) -> None:
+         # FIXME: this try-except block is for handling unexpected xgrammar issue.
+diff --git a/python/sglang/srt/managers/scheduler_components/output_streamer.py b/python/sglang/srt/managers/scheduler_components/output_streamer.py
+index f95c59f6f2..f5a1d25e51 100644
+--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
++++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
+@@ -43,6 +43,8 @@ class SchedulerOutputStreamer:
+     spec_algorithm: SpeculativeAlgorithm
+     disaggregation_mode: DisaggregationMode
+     enable_hicache_storage: Callable[[], bool]
++    # Spec training: lazy getter for the (background-initialized) EagleMooncakeStore.
++    get_eagle_mooncake_store: Callable[[], Any]
+     _test_stream_output_count: int = 0
+ 
+     def _get_storage_backend_type(self) -> str:
+@@ -131,6 +133,12 @@ class SchedulerOutputStreamer:
+             req.return_indexer_topk for req in reqs if req is not skip_req
+         )
+ 
++        # Spec training: flush any pending mooncake hidden-state writes before
++        # the per-request store keys are streamed out.
++        eagle_mooncake_store = self.get_eagle_mooncake_store()
++        if self.ps.attn_tp_rank == 0 and eagle_mooncake_store is not None:
++            eagle_mooncake_store.flush()
++
+         acc = _GenerationStreamAccumulator(
+             return_logprob=return_logprob,
+             return_hidden_states=return_hidden_states,
+@@ -141,6 +149,8 @@ class SchedulerOutputStreamer:
+             default_stream_interval=self.server_args.stream_interval,
+             default_force_stream_interval=DEFAULT_FORCE_STREAM_INTERVAL,
+             get_cached_tokens_details=self.get_cached_tokens_details,
++            attn_tp_rank=self.ps.attn_tp_rank,
++            eagle_mooncake_active=eagle_mooncake_store is not None,
+         )
+         for req in reqs:
+             if req is skip_req:
+@@ -247,6 +257,9 @@ class _GenerationStreamAccumulator:
+     default_stream_interval: int
+     default_force_stream_interval: int
+     get_cached_tokens_details: Callable[[Req], Optional[dict]]
++    # Spec training context
++    attn_tp_rank: int = 0
++    eagle_mooncake_active: bool = False
+ 
+     rids: list = field(default_factory=list)
+     http_worker_ipcs: list = field(default_factory=list)
+@@ -290,6 +303,11 @@ class _GenerationStreamAccumulator:
+     output_token_ids_logprobs_val: Optional[list] = None
+     output_token_ids_logprobs_idx: Optional[list] = None
+ 
++    # Spec training outputs (populated only on attn_tp_rank == 0)
++    spec_training_data_ids: Optional[list] = None
++    packed_loss_masks: Optional[list] = None
++    spec_training_mooncake_store_keys: Optional[list] = None
++
+     def __post_init__(self) -> None:
+         if self.return_hidden_states:
+             self.output_hidden_states = []
+@@ -298,6 +316,11 @@ class _GenerationStreamAccumulator:
+         if self.return_indexer_topk:
+             self.indexer_topk = []
+ 
++        if self.attn_tp_rank == 0:
++            self.spec_training_data_ids = []
++            self.packed_loss_masks = []
++            self.spec_training_mooncake_store_keys = []
++
+         if self.return_logprob:
+             self.input_token_logprobs_val = []
+             self.input_token_logprobs_idx = []
+@@ -400,6 +423,13 @@ class _GenerationStreamAccumulator:
+             self.spec_num_correct_drafts.append(req.spec_num_correct_drafts)
+             self.spec_correct_drafts_histogram.append(req.spec_correct_drafts_histogram)
+ 
++        if self.spec_training_data_ids is not None:
++            self.spec_training_data_ids.append(req.spec_training_data_id)
++            self.packed_loss_masks.append(req.packed_loss_mask)
++            self.spec_training_mooncake_store_keys.append(
++                req.spec_training_mooncake_store_keys
++            )
++
+         if self.return_logprob:
+             if (
+                 req.return_logprob
+@@ -474,7 +504,15 @@ class _GenerationStreamAccumulator:
+                 self.output_token_ids_logprobs_idx.append([])
+ 
+         if self.return_hidden_states:
+-            if req.return_hidden_states:
++            # Spec training requests transfer hidden states via the
++            # EagleMooncakeStore (RDMA), so skip the normal host payload to
++            # avoid double-sending; keep index alignment with None.
++            uses_mooncake = (
++                self.attn_tp_rank == 0
++                and req.spec_training_data_id is not None
++                and self.eagle_mooncake_active
++            )
++            if req.return_hidden_states and not uses_mooncake:
+                 # Mirror output_ids_through_stop: spec verify steps can overshoot finished_len.
+                 hs = req.hidden_states
+                 if req.finished_len is not None:
+@@ -547,4 +585,15 @@ class _GenerationStreamAccumulator:
+             placeholder_tokens_val=None,
+             retraction_counts=self.retraction_counts,
+             dp_ranks=dp_ranks,
++            spec_training_data_ids=(
++                self.spec_training_data_ids if self.spec_training_data_ids else None
++            ),
++            packed_loss_masks=(
++                self.packed_loss_masks if self.packed_loss_masks else None
++            ),
++            spec_training_mooncake_store_keys=(
++                self.spec_training_mooncake_store_keys
++                if self.spec_training_mooncake_store_keys
++                else None
++            ),
+         )
+diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
+index bf932611a5..97b4427c83 100644
+--- a/python/sglang/srt/managers/tokenizer_manager.py
++++ b/python/sglang/srt/managers/tokenizer_manager.py
+@@ -1172,6 +1172,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+                 multi_item_delimiter_indices=obj.multi_item_delimiter_indices,
+                 mm_data_mooncake=obj.mm_data_mooncake,
+                 encoder_urls=obj.encoder_urls,
++                spec_training_data_id=obj.spec_training_data_id,
++                packed_loss_mask=obj.packed_loss_mask,
+             )
+         elif isinstance(obj, EmbeddingReqInput):
+             # Resolve unresolved embed overrides now that input_ids are available
+@@ -1939,6 +1941,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+             if getattr(recv_obj, "dp_ranks", None):
+                 meta_info["dp_rank"] = recv_obj.dp_ranks[i]
+ 
++            if (
++                hasattr(recv_obj, "spec_training_data_ids")
++                and recv_obj.spec_training_data_ids is not None
++                and i < len(recv_obj.spec_training_data_ids)
++                and recv_obj.spec_training_data_ids[i] is not None
++            ):
++                meta_info["spec_training_data_id"] = recv_obj.spec_training_data_ids[i]
++                meta_info["packed_loss_mask"] = recv_obj.packed_loss_masks[i]
++                meta_info["spec_training_mooncake_store_keys"] = (
++                    recv_obj.spec_training_mooncake_store_keys[i]
++                )
++
+             state.finished = recv_obj.finished_reasons[i] is not None
+             if isinstance(recv_obj, BatchStrOutput):
+                 # Not all request types have `stream` (e.g., EmbeddingReqInput). Default to non-streaming.
+diff --git a/python/sglang/srt/model_executor/forward_batch_info.py b/python/sglang/srt/model_executor/forward_batch_info.py
+index 0feeca8317..cf3c783241 100644
+--- a/python/sglang/srt/model_executor/forward_batch_info.py
++++ b/python/sglang/srt/model_executor/forward_batch_info.py
+@@ -602,6 +602,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+         if skip_attn_backend_init:
+             self.mark_forward_metadata_ready()
+ 
++    # For spec training
++    has_spec_training: bool = False
++
+     @classmethod
+     def init_new(
+         cls,
+@@ -621,7 +624,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+         # capture_hidden_mode default: derive from SB.return_hidden_states /
+         # spec_info.capture_hidden_mode when caller did not override.
+         if capture_hidden_mode is None:
+-            if batch.return_hidden_states:
++            if batch.return_hidden_states or batch.spec_training_info is not None:
+                 capture_hidden_mode = CaptureHiddenMode.FULL
+             elif batch.spec_info is not None:
+                 capture_hidden_mode = getattr(
+@@ -709,6 +712,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+             encoder_lens_cpu=batch.encoder_lens_cpu,
+             lora_ids=[req.lora_id for req in batch.reqs],
+             rids=[req.rid for req in batch.reqs],
++            # For spec training
++            has_spec_training=batch.spec_training_info is not None,
+             # Compound (carry their own device tensors)
+             sampling_info=batch.sampling_info,
+             spec_info=batch.spec_info,
+diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
+index 1cff5c9839..80e924bd4f 100644
+--- a/python/sglang/srt/model_executor/model_runner.py
++++ b/python/sglang/srt/model_executor/model_runner.py
+@@ -471,6 +471,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+                     # if there is no aux layer, set to None
+                     self.eagle_aux_hidden_state_layer_ids = None
+ 
++        if self.server_args.enable_aux_hidden_states:
++            self.eagle_use_aux_hidden_state = True
++            if self.server_args.aux_hidden_state_layer_ids is not None:
++                self.eagle_aux_hidden_state_layer_ids = (
++                    self.server_args.aux_hidden_state_layer_ids
++                )
++
+         if self.spec_algorithm.is_dflash() and not self.is_draft_worker:
+             from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
+ 
+@@ -1006,6 +1013,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+         include aux hidden state output paths.
+         """
+         if self.eagle_use_aux_hidden_state:
++            if not hasattr(self.model, "set_eagle3_layers_to_capture"):
++                raise RuntimeError(
++                    "Aux hidden state capture is not supported by this model."
++                )
+             self.model.set_eagle3_layers_to_capture(
+                 self.eagle_aux_hidden_state_layer_ids
+             )
+@@ -3107,6 +3118,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+         """
+         self._preprocess_logits(logits_output, forward_batch.sampling_info)
+ 
++        # Spec training: skip sampling and return fake EOS tokens.
++        if logits_output.skip_sampling_next_token_ids is not None:
++            return logits_output.skip_sampling_next_token_ids
++
+         # Sample the next tokens
+         next_token_ids = self.sampler(
+             logits_output,
+diff --git a/python/sglang/srt/models/qwen3_next.py b/python/sglang/srt/models/qwen3_next.py
+index f085fb43d4..943af29bbb 100644
+--- a/python/sglang/srt/models/qwen3_next.py
++++ b/python/sglang/srt/models/qwen3_next.py
+@@ -1033,6 +1033,7 @@ class Qwen3NextForCausalLM(nn.Module):
+         self.logits_processor = LogitsProcessor(config)
+         # For EAGLE3 support
+         self.capture_aux_hidden_states = False
++        self.hot_token_id = None
+ 
+         self.num_fused_shared_experts = self._get_num_fused_shared_experts()
+         if self.num_fused_shared_experts > 1:
+@@ -1147,6 +1148,13 @@ class Qwen3NextForCausalLM(nn.Module):
+         loaded_params: Set[str] = set()
+         for name, loaded_weight in weights:
+ 
++            if "d2t" in name:
++                self.hot_token_id = loaded_weight + torch.arange(loaded_weight.shape[0])
++                continue
++
++            if "t2d" in name:
++                continue
++
+             if is_mtp:
+ 
+                 if "mtp" not in name:
+diff --git a/python/sglang/srt/models/qwen3_next_mtp.py b/python/sglang/srt/models/qwen3_next_mtp.py
+index 69adf12a7d..7a262df12b 100644
+--- a/python/sglang/srt/models/qwen3_next_mtp.py
++++ b/python/sglang/srt/models/qwen3_next_mtp.py
+@@ -101,6 +101,9 @@ class Qwen3NextForCausalLMMTP(Qwen3NextForCausalLM):
+             )
+         self.enable_shared_expert_fusion = self.num_fused_shared_experts > 0
+ 
++        self.capture_aux_hidden_states = False
++        self.hot_token_id = None
++
+     @torch.no_grad()
+     def forward(
+         self,
+diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
+index c7162c16d5..8cf92f4cad 100644
+--- a/python/sglang/srt/server_args.py
++++ b/python/sglang/srt/server_args.py
+@@ -1550,6 +1550,29 @@ class ServerArgs:
+         "Path to a JSON config file for adaptive speculative decoding tuning knobs.",
+     ] = None
+ 
++    # -------------------------------------------------------------------------
++    # Spec training (for speculative decoding model training)
++    # -------------------------------------------------------------------------
++    enable_spec_training_mooncake: A[
++        bool,
++        "Enable EagleMooncakeStore for spec training hidden state transfer.",
++    ] = False
++    enable_aux_hidden_states: A[
++        bool,
++        "Enable capturing auxiliary hidden states for supported models.",
++    ] = False
++    aux_hidden_state_layer_ids: A[
++        Optional[List[int]],
++        "Layer IDs to capture as auxiliary hidden states. If omitted, model defaults are used.",
++    ] = None
++    spec_training_store_last_hidden_states: A[
++        bool,
++        Arg(
++            help="Whether to store last hidden states for spec training requests.",
++            action=argparse.BooleanOptionalAction,
++        ),
++    ] = True
++
+     # -------------------------------------------------------------------------
+     # Speculative decoding (ngram)
+     # -------------------------------------------------------------------------
+diff --git a/python/sglang/srt/speculative/spec_training_info.py b/python/sglang/srt/speculative/spec_training_info.py
+new file mode 100644
+index 0000000000..24af14b7a4
+--- /dev/null
++++ b/python/sglang/srt/speculative/spec_training_info.py
+@@ -0,0 +1,50 @@
++from dataclasses import dataclass, field
++from typing import Dict, List, Optional
++
++
++@dataclass
++class SpecTrainingInfo:
++    """Tracks spec training info for requests in a batch.
++
++    Keys:
++    - data_ids: rid -> data_id mapping
++    - packed_loss_masks: data_id -> packed_loss_mask string
++    - mooncake_store_keys: data_id -> list of keys
++    """
++
++    data_ids: Dict[str, str] = field(default_factory=dict)
++    packed_loss_masks: Dict[str, str] = field(default_factory=dict)
++    mooncake_store_keys: Dict[str, List[str]] = field(default_factory=dict)
++
++    def add_request(
++        self,
++        rid: str,
++        data_id: Optional[str],
++        packed_loss_mask: Optional[str],
++    ):
++        """Add spec training info for a request if it's a spec training request."""
++        if data_id is not None:
++            self.data_ids[rid] = data_id
++            self.packed_loss_masks[data_id] = packed_loss_mask
++            if data_id not in self.mooncake_store_keys:
++                self.mooncake_store_keys[data_id] = []
++
++    def has_request(self, rid: str) -> bool:
++        return rid in self.data_ids
++
++    def set_mooncake_store_keys(self, data_id: str, keys: List[str]):
++        if data_id in self.mooncake_store_keys:
++            self.mooncake_store_keys[data_id] = keys
++
++    def remove_request(self, rid: str):
++        data_id = self.data_ids.pop(rid, None)
++        if data_id is not None:
++            remaining_rids_with_data_id = [
++                r for r, d in self.data_ids.items() if d == data_id
++            ]
++            if not remaining_rids_with_data_id:
++                self.packed_loss_masks.pop(data_id, None)
++                self.mooncake_store_keys.pop(data_id, None)
++
++    def is_empty(self) -> bool:
++        return len(self.data_ids) == 0

--- a/tools/apply_sglang_patch.sh
+++ b/tools/apply_sglang_patch.sh
@@ -19,7 +19,7 @@ if [ "${1:-}" = "--decode" ]; then
     shift
 fi
 
-SGLANG_VERSION="${SGLANG_VERSION:-v0.5.10.post1}"
+SGLANG_VERSION="${SGLANG_VERSION:-v0.5.14}"
 SGLANG_DIR="$PROJECT_ROOT/docker/sglang/$SGLANG_VERSION"
 
 if [ ! -d "$SGLANG_DIR" ]; then

--- a/tools/build_conda.sh
+++ b/tools/build_conda.sh
@@ -41,12 +41,12 @@ if command -v micromamba &> /dev/null; then
     ENV_MANAGER="micromamba"
     export MAMBA_EXE="${MAMBA_EXE:-$(command -v micromamba)}"
     export MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-$HOME/micromamba}"
-    ENV_CREATE_CMD=("$MAMBA_EXE" create -n torchspec python=3.12 uv -c conda-forge -y)
+    ENV_CREATE_CMD=("$MAMBA_EXE" create -n torchspec python=3.12 pip uv -c conda-forge -y)
     ENV_RUN_CMD=("$MAMBA_EXE" run -n torchspec)
     ACTIVATE_HINT="micromamba activate torchspec"
 elif command -v conda &> /dev/null; then
     ENV_MANAGER="conda"
-    ENV_CREATE_CMD=(conda create -n torchspec python=3.12 uv -c conda-forge -y)
+    ENV_CREATE_CMD=(conda create -n torchspec python=3.12 pip uv -c conda-forge -y)
     ENV_RUN_CMD=(conda run -n torchspec)
     ACTIVATE_HINT="conda activate torchspec"
 fi
@@ -73,8 +73,8 @@ if [ "$BACKEND" = "sglang" ] || [ "$BACKEND" = "both" ]; then
     echo "Installing SGLang..."
     echo "=========================================="
 
-    SGLANG_VERSION="${SGLANG_VERSION:-v0.5.10.post1}"
-    SGLANG_COMMIT=94f03a39dbd39edfc2b118b5357bbbadaaa9ad28
+    SGLANG_VERSION="${SGLANG_VERSION:-v0.5.14}"
+    SGLANG_COMMIT=4289f36ef960fad8268a6b94935686e792a81432
     SGLANG_FOLDER_NAME="_sglang"
 
     # Install sglang inside the conda environment

--- a/tools/update_sglang_patch.sh
+++ b/tools/update_sglang_patch.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
-SGLANG_VERSION="${SGLANG_VERSION:-v0.5.10.post1}"
+SGLANG_VERSION="${SGLANG_VERSION:-v0.5.14}"
 SGLANG_DIR="$PROJECT_ROOT/docker/sglang/$SGLANG_VERSION"
 
 if [ ! -d "$SGLANG_DIR" ]; then


### PR DESCRIPTION
# Overview

Bumps SGLang version to 0.5.14 along with minor setup fixes

- Setup script did not install pip by default, causing first-time setup to crash. Updated env creation to include pip as well.
- Add patches & dockerfile for SGLang 0.5.14 training.
- Add an early exit to "examples/qwen3-8b-single-node/run.sh" to catch annoying startup bugs early.

# Motivation

Training drafters for Qwen3.5 with SGLang requires the latest version. Currently vLLM doesn't support DFlash for Qwen3.5 family, so the only engine with stable DFlash for Qwen3.5 is SGlang.

# Testing

Recreate the environment + launch "examples/qwen3-8b-single-node/run.sh"


<img width="1630" height="630" alt="image" src="https://github.com/user-attachments/assets/fc0060dd-693a-4d94-8828-bbc2d3052db4" />

Will follow-up with DFlash recipe for Qwen3.5/6 soon.