### PR TITLE
feat: add DFlash2 training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ python tools/convert_to_hf.py --input-dir ./outputs/my_experiment/iter_0010000/
 
 Vocabulary pruning, which reduces the draft model `lm_head` to a smaller token set and emits `d2t` and `t2d` mappings, can be applied either during training or at conversion time.
 
+DFlash2 requires the full target vocabulary. Do not set `draft_vocab_size` or pass `--prune-vocab` for a DFlash2 model.
+
 - **Pre-pruning**: set `draft_vocab_size` in your training config. The checkpoint already contains the pruned `lm_head` and `d2t`/`t2d` buffers, so the basic conversion command is enough.
 - **Post-pruning**: train with the full vocabulary, then pass `--prune-vocab` at conversion time together with a representative dataset to compute token frequencies.
 

--- a/THIRDPARTYNOTICES
+++ b/THIRDPARTYNOTICES
@@ -204,6 +204,32 @@ Notice for THUDM/slime
    See the License for the specific language governing permissions and
    limitations under the License.
 
+Notice for z-lab/dflash
+-------------------------------
+Source: https://github.com/z-lab/dflash/tree/07ebd93db9f472af339b644bb70221ad8428328a
+
+MIT License
+
+Copyright (c) 2026 Z Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 Notice for sgl-project/SpecForge
 -------------------------------
 

--- a/configs/sglang_qwen3_8b_dflash2.yaml
+++ b/configs/sglang_qwen3_8b_dflash2.yaml
@@ -1,0 +1,68 @@
+model:
+  target_model_path: Qwen/Qwen3-8B
+  trust_remote_code: true
+  draft_model_config: torchspec/config/dflash2_draft_config.json
+
+dataset:
+  train_data_path: ../examples/data/sample_conversations.jsonl
+  eval_data_path: null
+  eval_interval: 100
+  chat_template: qwen
+  prompt_key: conversations
+  min_loss_tokens: 32
+
+training:
+  attention_backend: flex_attention
+  micro_batch_size: 1
+  draft_accumulation_steps: 2
+  learning_rate: 6e-4
+  min_lr: 6e-5
+  weight_decay: 0.01
+  max_concurrent_batches: 1
+  max_grad_norm: 1.0
+  max_seq_length: 2048
+  num_epochs: 3
+  seed: 42
+  training_num_gpus_per_node: 4
+  training_num_nodes: 1
+  ttt_length: 7
+  fsdp_strategy: FULL_SHARD
+  fsdp_reduce_dtype: bfloat16
+  prefetch_depth: 8
+  save_interval: 1000
+  save_per_epoch: true
+  max_checkpoints: 2
+  warmup_ratio: 0.04
+  dflash_block_size: 8
+  dflash_num_anchors: 512
+  dflash_loss_decay_gamma: 7.0
+  dflash_num_target_layers: 5
+  dflash2_selector_loss_alpha: 1.0
+
+inference:
+  inference_engine_type: sgl
+  store_last_hidden_states: false
+  inference_num_gpus: 4
+  inference_num_gpus_per_engine: 1
+  inference_num_gpus_per_node: 4
+  max_sample_pool_size: 64
+  inference_buffer_threshold: 32
+  inference_batch_size: 8
+  sglang:
+    tp_size: 1
+    mem_fraction_static: 0.7
+
+mooncake:
+  master_server_address: null
+  metadata_server: null
+  protocol: tcp
+  global_segment_size: 16GB
+  local_buffer_size: 4GB
+  enable_hard_pin: true
+
+output_dir: ./outputs/qwen3-8b-dflash2
+cache_dir: ./cache/qwen3-8b-dflash2
+model_download_dir: null
+
+debug:
+  save_debug_train_data: null

--- a/tests/test_dflash2.py
+++ b/tests/test_dflash2.py
@@ -1,0 +1,891 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import load_file
+
+from tools.convert_to_hf import (
+    _convert_fsdp_to_hf,
+    _fixup_export_config,
+)
+from torchspec.models.dflash import _create_dflash_mask_mod
+from torchspec.models.dflash2 import DFlash2Model
+from torchspec.models.draft.auto import AutoDraftModelConfig
+from torchspec.models.draft.dflash import DFlashConfig
+from torchspec.models.draft.dflash2 import (
+    CandidateSelector,
+    DFlash2Config,
+    DFlash2DraftModel,
+    DFlashGroupedConv,
+)
+from torchspec.training.trainer_actor import _trainer_class_for_config
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_dflash2_trainer():
+    mooncake = ModuleType("mooncake")
+    mooncake.__path__ = []
+    mooncake_store = ModuleType("mooncake.store")
+    mooncake_store.MooncakeDistributedStore = type("MooncakeDistributedStore", (), {})
+    mooncake_store.ReplicateConfig = type("ReplicateConfig", (), {})
+    missing = object()
+    previous = {name: sys.modules.get(name, missing) for name in ("mooncake", "mooncake.store")}
+    sys.modules.update({"mooncake": mooncake, "mooncake.store": mooncake_store})
+    try:
+        from torchspec.training.dflash2_trainer import DFlash2Trainer
+
+        return DFlash2Trainer
+    finally:
+        for name, module in previous.items():
+            if module is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def _tiny_config_kwargs(**overrides):
+    config = {
+        "hidden_size": 4,
+        "intermediate_size": 8,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "vocab_size": 8,
+        "num_target_layers": 4,
+        "block_size": 2,
+        "conv_group_size": 2,
+        "selector_rank": 2,
+        "selector_top_k": 2,
+        "mask_token_id": 7,
+    }
+    config.update(overrides)
+    return config
+
+
+def _make_config(
+    hidden_size=16,
+    vocab_size=32,
+    num_target_layers=2,
+    block_size=4,
+    selector_rank=4,
+    selector_top_k=None,
+):
+    num_attention_heads = min(4, hidden_size)
+    return DFlash2Config(
+        architectures=["DFlash2DraftModel"],
+        hidden_size=hidden_size,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=max(1, num_attention_heads // 2),
+        vocab_size=vocab_size,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        num_target_layers=num_target_layers,
+        target_hidden_size=hidden_size,
+        target_num_hidden_layers=12,
+        target_layer_ids=[1, 9][:num_target_layers],
+        mask_token_id=vocab_size - 1,
+        block_size=block_size,
+        conv_kernel_size=2,
+        conv_group_size=min(4, hidden_size),
+        selector_rank=selector_rank,
+        selector_top_k=selector_top_k if selector_top_k is not None else min(4, vocab_size),
+    )
+
+
+def _make_model(selector_loss_alpha=0.4):
+    config = _make_config()
+    draft = DFlash2DraftModel(config).to(dtype=torch.float32)
+    draft.freeze_embedding()
+    return DFlash2Model(
+        draft_model=draft,
+        block_size=config.block_size,
+        num_anchors=2,
+        loss_decay_gamma=4.0,
+        selector_loss_alpha=selector_loss_alpha,
+    )
+
+
+def _batch(seed=0, all_masked=False):
+    generator = torch.Generator().manual_seed(seed)
+    batch_size, sequence_length, hidden_size, vocab_size = 2, 12, 16, 32
+    loss_mask = torch.zeros(batch_size, sequence_length)
+    if not all_masked:
+        loss_mask[:, 2:] = 1
+    return {
+        "input_ids": torch.randint(
+            0, vocab_size - 1, (batch_size, sequence_length), generator=generator
+        ),
+        "hidden_states_list": [
+            torch.randn(batch_size, sequence_length, hidden_size, generator=generator)
+            for _ in range(2)
+        ],
+        "loss_mask": loss_mask,
+        "lm_head_weight": torch.randn(vocab_size, hidden_size, generator=generator),
+    }
+
+
+class TestDFlash2Config(unittest.TestCase):
+    def test_repository_config_dispatches_to_dflash2(self):
+        config_path = ROOT / "torchspec" / "config" / "dflash2_draft_config.json"
+        self.assertTrue(config_path.is_file())
+
+        config = AutoDraftModelConfig.from_file(str(config_path))
+
+        self.assertIsInstance(config, DFlash2Config)
+        self.assertEqual(config.architectures, ["DFlash2DraftModel"])
+        self.assertGreater(config.block_size, 1)
+        trainer_module = ModuleType("torchspec.training.dflash2_trainer")
+        trainer_class = type("DFlash2Trainer", (), {})
+        trainer_module.DFlash2Trainer = trainer_class
+        with mock.patch.dict("sys.modules", {"torchspec.training.dflash2_trainer": trainer_module}):
+            self.assertIs(_trainer_class_for_config(config), trainer_class)
+
+    def test_legacy_dflash_dispatch_is_unchanged(self):
+        config = AutoDraftModelConfig.from_dict(
+            {
+                "architectures": ["DFlashDraftModel"],
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "vocab_size": 32,
+                "num_target_layers": 2,
+                "target_hidden_size": 16,
+                "target_num_hidden_layers": 12,
+            }
+        )
+
+        self.assertIs(type(config), DFlashConfig)
+        trainer_module = ModuleType("torchspec.training.dflash_trainer")
+        trainer_class = type("DFlashTrainer", (), {})
+        trainer_module.DFlashTrainer = trainer_class
+        with mock.patch.dict("sys.modules", {"torchspec.training.dflash_trainer": trainer_module}):
+            self.assertIs(_trainer_class_for_config(config), trainer_class)
+
+    def test_official_nested_config_semantics(self):
+        config = AutoDraftModelConfig.from_dict(
+            _tiny_config_kwargs(
+                architectures=["DFlash2DraftModel"],
+                model_type="qwen3",
+                hidden_size=16,
+                intermediate_size=32,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                vocab_size=32,
+                rope_parameters={"rope_theta": 12345.0},
+                num_target_layers=12,
+                use_sliding_window=False,
+                sliding_window=2048,
+                is_causal=False,
+                layer_types=["sliding_attention"],
+                dflash_config={
+                    "block_size": 4,
+                    "target_layer_ids": [1, 9],
+                    "mask_token_id": 31,
+                    "conv_kernel_size": 2,
+                    "conv_group_size": 4,
+                    "selector_rank": 4,
+                    "selector_top_k": 8,
+                },
+            )
+        )
+
+        self.assertIsInstance(config, DFlash2Config)
+        self.assertEqual(config.model_type, "qwen3_dflash2")
+        self.assertEqual(config.num_target_layers, 2)
+        self.assertEqual(config.target_num_hidden_layers, 12)
+        self.assertEqual(config.target_layer_ids, [1, 9])
+        self.assertEqual(config.rope_theta, 12345.0)
+        self.assertEqual(config.block_size, 4)
+        self.assertEqual(config.conv_kernel_size, 2)
+        self.assertEqual(config.conv_group_size, 4)
+        self.assertEqual(config.selector_rank, 4)
+        self.assertEqual(config.selector_top_k, 8)
+        self.assertEqual(config.sliding_window, 2048)
+        self.assertFalse(config.is_causal)
+        self.assertEqual(config.target_hidden_size, config.hidden_size)
+
+        model = DFlash2Model(
+            DFlash2DraftModel(config),
+            block_size=config.block_size,
+            num_anchors=1,
+        )
+        self.assertEqual(
+            model._block_mask_options(),
+            {"is_causal": False, "sliding_window": 2048},
+        )
+
+    def test_missing_target_layer_ids_are_derived_from_target_depth(self):
+        config = DFlash2Config(
+            **_tiny_config_kwargs(
+                hidden_size=16,
+                intermediate_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                vocab_size=32,
+                num_target_layers=12,
+                block_size=4,
+                conv_group_size=4,
+                selector_rank=4,
+                selector_top_k=4,
+            )
+        )
+
+        self.assertEqual(config.target_num_hidden_layers, 12)
+        self.assertEqual(config.num_target_layers, 2)
+        self.assertEqual(config.target_layer_ids, [1, 9])
+        self.assertEqual(DFlash2DraftModel(config).context_proj.in_features, 32)
+
+        sliding = DFlash2Config(
+            **_tiny_config_kwargs(
+                num_hidden_layers=2,
+                use_sliding_window=True,
+                sliding_window=4096,
+                max_window_layers=0,
+            )
+        )
+        self.assertEqual(sliding.layer_types, ["sliding_attention", "sliding_attention"])
+        self.assertEqual(sliding.sliding_window, 4096)
+
+        equal_depth = DFlash2Config(
+            **_tiny_config_kwargs(
+                num_hidden_layers=2,
+                num_target_layers=2,
+                dflash_config={"target_layer_ids": [0, 1]},
+            )
+        )
+        self.assertEqual(equal_depth.target_num_hidden_layers, 2)
+        self.assertEqual(
+            DFlash2DraftModel(equal_depth).config_for_serving()["num_target_layers"],
+            2,
+        )
+
+        omitted_block_size = _tiny_config_kwargs()
+        omitted_block_size.pop("block_size")
+        self.assertEqual(DFlash2Config(**omitted_block_size).block_size, 16)
+
+        for model_type in ("qwen3", "qwen3_dflash2"):
+            with self.subTest(model_type=model_type):
+                self.assertEqual(
+                    DFlash2Config(**_tiny_config_kwargs(model_type=model_type)).model_type,
+                    "qwen3_dflash2",
+                )
+
+    def test_invalid_config_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "conv_kernel_size"):
+            DFlash2Config(**_tiny_config_kwargs(conv_kernel_size=3))
+
+        for target_layer_ids in ([1, 12], [-1, 9], []):
+            with self.subTest(target_layer_ids=target_layer_ids):
+                with self.assertRaisesRegex(ValueError, "target_layer_ids"):
+                    DFlash2Config(
+                        **_tiny_config_kwargs(
+                            num_hidden_layers=2,
+                            num_target_layers=12,
+                            target_layer_ids=target_layer_ids,
+                        )
+                    )
+
+        unsupported_qwen_options = (
+            ({"hidden_act": "relu"}, "hidden_act"),
+            ({"attention_bias": True}, "attention_bias"),
+            ({"attention_dropout": 0.1}, "attention_dropout"),
+            ({"fc_norm": True}, "fc_norm"),
+            ({"draft_vocab_size": 4}, "draft_vocab_size"),
+            ({"target_hidden_size": 8}, "target_hidden_size"),
+            ({"input_embedding_scale": -1.0}, "input_embedding_scale"),
+            ({"input_embedding_scale": 0.0}, "input_embedding_scale"),
+            ({"input_embedding_scale": float("nan")}, "input_embedding_scale"),
+            ({"input_embedding_scale": float("inf")}, "input_embedding_scale"),
+            ({"mask_token_id": -1}, "mask_token_id"),
+            ({"mask_token_id": 8}, "mask_token_id"),
+            ({"model_type": "llama"}, "model_type"),
+            ({"output_multiplier": 0.0}, "output_multiplier"),
+            ({"output_multiplier": float("nan")}, "output_multiplier"),
+            ({"final_logit_softcapping": -1.0}, "final_logit_softcapping"),
+            ({"final_logit_softcapping": float("nan")}, "final_logit_softcapping"),
+            ({"rope_scaling": {"factor": 2.0}}, "rope_scaling"),
+            ({"rope_parameters": {"rope_type": "linear"}}, "rope_parameters"),
+        )
+        for options, error in unsupported_qwen_options:
+            with self.subTest(options=options):
+                with self.assertRaisesRegex(ValueError, error):
+                    DFlash2Config(**_tiny_config_kwargs(**options))
+
+        invalid_layer_types = (
+            (["full_attention", "full_attention"], 1, "one entry"),
+            (["linear_attention"], 1, "Unsupported"),
+            (["full_attention", "sliding_attention"], 2, "mixed"),
+        )
+        for layer_types, num_hidden_layers, error in invalid_layer_types:
+            with self.subTest(layer_types=layer_types):
+                with self.assertRaisesRegex(ValueError, error):
+                    DFlash2Config(
+                        **_tiny_config_kwargs(
+                            num_hidden_layers=num_hidden_layers,
+                            layer_types=layer_types,
+                            sliding_window=2048,
+                        )
+                    )
+
+        for sliding_window in (None, 0):
+            with self.subTest(sliding_window=sliding_window):
+                with self.assertRaisesRegex(ValueError, "sliding_window"):
+                    DFlash2Config(
+                        **_tiny_config_kwargs(
+                            layer_types=["sliding_attention"],
+                            sliding_window=sliding_window,
+                        )
+                    )
+
+        self.assertIsNone(
+            DFlash2Config(
+                **_tiny_config_kwargs(final_logit_softcapping=0.0)
+            ).final_logit_softcapping
+        )
+
+    def test_explicit_capture_layers_must_match_dflash2_config(self):
+        from torchspec.train_entry import _validate_and_configure_dflash
+
+        config = _make_config()
+        args = Namespace(
+            inference_engine_type="sgl",
+            defer_tokenization=False,
+            dflash_block_size=4,
+            dflash_num_target_layers=2,
+            min_loss_tokens=8,
+            aux_hidden_states_layers=[1, 8],
+        )
+
+        with self.assertRaisesRegex(ValueError, "aux_hidden_states_layers"):
+            _validate_and_configure_dflash(args, config)
+
+        args.aux_hidden_states_layers = config.target_layer_ids
+        args.draft_accumulation_steps = 2
+        _validate_and_configure_dflash(args, config)
+
+        args.attention_backend = "usp"
+        with self.assertRaisesRegex(ValueError, "attention_backend=usp"):
+            _validate_and_configure_dflash(args, config)
+
+
+class TestDFlashGroupedConv(unittest.TestCase):
+    def setUp(self):
+        self.conv = DFlashGroupedConv(
+            hidden_size=4,
+            kernel_size=2,
+            group_size=2,
+            block_size=3,
+        )
+        with torch.no_grad():
+            self.conv.kernel_projection.weight.zero_()
+            self.conv.base_kernel.zero_()
+            self.conv.base_kernel[0, 1].fill_(1)
+            self.conv.base_kernel[1, 0].fill_(2)
+            self.conv.base_kernel[1, 1].fill_(3)
+
+    def test_parameter_schema_and_block_boundary(self):
+        self.assertEqual(self.conv.base_kernel.shape, (2, 2, 4))
+        self.assertEqual(self.conv.kernel_projection.weight.shape, (8, 4))
+        hidden = torch.arange(24, dtype=torch.float32).view(1, 6, 4)
+        with torch.no_grad():
+            self.conv.kernel_projection.weight[:, 0] = torch.tensor(
+                [0.1, 0.1, 0.2, 0.2, 0.3, 0.4, 0.5, 0.6]
+            )
+
+        prepared, finish_kernel = self.conv.prepare(hidden)
+
+        shifted = torch.zeros_like(hidden)
+        shifted[:, 1:3] = hidden[:, 0:2]
+        shifted[:, 4:6] = hidden[:, 3:5]
+        position_scale = hidden[..., :1]
+        expected = 0.1 * position_scale * hidden + (1 + 0.2 * position_scale) * shifted
+        torch.testing.assert_close(prepared, expected)
+        self.assertEqual(finish_kernel.shape, (1, 6, 2, 2))
+        torch.testing.assert_close(finish_kernel[..., 0, 0], 0.3 * position_scale[..., 0])
+        torch.testing.assert_close(finish_kernel[..., 0, 1], 0.4 * position_scale[..., 0])
+        torch.testing.assert_close(finish_kernel[..., 1, 0], 0.5 * position_scale[..., 0])
+        torch.testing.assert_close(finish_kernel[..., 1, 1], 0.6 * position_scale[..., 0])
+
+        finished = self.conv.finish(prepared, finish_kernel)
+        shifted = torch.zeros_like(prepared)
+        shifted[:, 1:3] = prepared[:, 0:2]
+        shifted[:, 4:6] = prepared[:, 3:5]
+        expected = torch.empty_like(finished)
+        expected[..., :2] = (2 + 0.3 * position_scale) * prepared[..., :2] + (
+            3 + 0.5 * position_scale
+        ) * shifted[..., :2]
+        expected[..., 2:] = (2 + 0.4 * position_scale) * prepared[..., 2:] + (
+            3 + 0.6 * position_scale
+        ) * shifted[..., 2:]
+        torch.testing.assert_close(finished, expected)
+
+    def test_output_is_causal_within_each_block(self):
+        with torch.no_grad():
+            self.conv.kernel_projection.weight.copy_(
+                torch.arange(32, dtype=torch.float32).view(8, 4) / 100
+            )
+        hidden = torch.arange(24, dtype=torch.float32).view(1, 6, 4)
+        changed = hidden.clone()
+        changed[:, 2] = -1000
+
+        baseline, _ = self.conv.prepare(hidden)
+        modified, _ = self.conv.prepare(changed)
+
+        self.assertTrue(torch.equal(modified[:, :2], baseline[:, :2]))
+        self.assertFalse(torch.equal(modified[:, 2], baseline[:, 2]))
+        self.assertTrue(torch.equal(modified[:, 3:], baseline[:, 3:]))
+
+
+class TestCandidateSelector(unittest.TestCase):
+    def test_scores_match_public_inference_lattice_rows(self):
+        selector = CandidateSelector(hidden_size=2, vocab_size=4, rank=2, top_k=2)
+        with torch.no_grad():
+            selector.predecessor_codebook.copy_(
+                torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+            )
+            selector.successor_codebook.copy_(
+                torch.tensor([[0.5, 1.0], [1.5, 2.0], [2.5, 3.0], [3.5, 4.0]])
+            )
+            selector.hidden_projection.weight.copy_(torch.eye(2))
+
+        hidden = torch.tensor([[[2.0, 3.0], [5.0, 7.0]]])
+        logits = torch.tensor([[[0.1, 0.7, 0.2, 0.4], [0.6, 0.3, 0.9, 0.2]]])
+        anchor_ids = torch.tensor([1])
+
+        unary, public_candidate_ids = torch.topk(logits, 2, dim=-1, sorted=False)
+        public_predecessor_ids = torch.cat(
+            (
+                anchor_ids[:, None, None].expand(-1, 1, 2),
+                public_candidate_ids[:, :-1],
+            ),
+            dim=1,
+        )
+        public_lattice = unary[:, :, None] + torch.einsum(
+            "blpr,blcr->blpc",
+            selector.predecessor_codebook[public_predecessor_ids] * hidden[:, :, None],
+            selector.successor_codebook[public_candidate_ids],
+        )
+
+        previous_indices = torch.zeros(1, dtype=torch.long)
+        selected_tokens = []
+        realized_rows = []
+        for position in range(hidden.shape[1]):
+            row = public_lattice[:, position].gather(
+                1,
+                previous_indices[:, None, None].expand(-1, 1, selector.top_k),
+            )[:, 0]
+            previous_indices = row.argmax(dim=-1)
+            selected_tokens.append(
+                public_candidate_ids[:, position].gather(-1, previous_indices[:, None])[:, 0]
+            )
+            realized_rows.append(row)
+        selected_tokens = torch.stack(selected_tokens, dim=1)
+        predecessor_ids = torch.cat((anchor_ids[:, None], selected_tokens[:, :-1]), dim=1)
+
+        scores, candidate_ids = selector.score_candidates(hidden, logits, predecessor_ids)
+
+        self.assertTrue(torch.equal(candidate_ids, public_candidate_ids))
+        self.assertTrue(torch.allclose(scores, torch.stack(realized_rows, dim=1), atol=1e-6))
+
+    def test_training_candidates_replace_the_weakest_candidate_with_gold(self):
+        selector = CandidateSelector(hidden_size=2, vocab_size=4, rank=2, top_k=2)
+        hidden = torch.ones(1, 1, 2)
+        logits = torch.tensor([[[0.1, 0.9, 0.8, 0.2]]])
+
+        _, candidate_ids = selector.score_candidates(
+            hidden,
+            logits,
+            predecessor_ids=torch.tensor([[3]]),
+            training_successor_ids=torch.tensor([[0]]),
+        )
+
+        self.assertEqual(set(candidate_ids[0, 0].tolist()), {0, 1})
+
+        present_selector = CandidateSelector(hidden_size=2, vocab_size=4, rank=2, top_k=3)
+        top_k = torch.topk(logits, 3, dim=-1, sorted=False)
+        weakest_index = top_k.values.argmin(dim=-1).item()
+        gold_index = 1 if weakest_index != 1 else 2
+        gold_id = top_k.indices[..., gold_index]
+        _, present_candidate_ids = present_selector.score_candidates(
+            hidden,
+            logits,
+            predecessor_ids=torch.tensor([[3]]),
+            training_successor_ids=gold_id,
+        )
+        self.assertEqual(
+            set(present_candidate_ids[0, 0].tolist()),
+            set(top_k.indices[0, 0].tolist()),
+        )
+        self.assertEqual(present_candidate_ids[0, 0].unique().numel(), 3)
+
+
+class TestDFlash2Forward(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(7)
+        self.model = _make_model()
+
+    def test_selector_loss_uses_teacher_forced_transitions_and_prefix_mask(self):
+        config = _make_config(
+            hidden_size=4,
+            vocab_size=4,
+            num_target_layers=1,
+            selector_rank=1,
+            selector_top_k=2,
+        )
+        model = DFlash2Model(
+            DFlash2DraftModel(config),
+            block_size=4,
+            num_anchors=1,
+            selector_loss_alpha=0.4,
+        )
+        selector = model.draft_model.candidate_selector
+        with torch.no_grad():
+            selector.hidden_projection.weight.copy_(torch.tensor([[1.0, 0.0, 0.0, 0.0]]))
+            selector.predecessor_codebook.copy_(torch.tensor([[1.0], [2.0], [3.0], [4.0]]))
+            selector.successor_codebook.copy_(torch.tensor([[0.5], [1.0], [1.5], [2.0]]))
+
+        hidden = torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0, 0.0],
+                    [3.0, 0.0, 0.0, 0.0],
+                ]
+            ]
+        )
+        logits = torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.1, 0.0, 3.0, 2.0],
+                    [0.1, 3.0, 0.0, 2.0],
+                    [3.0, 2.0, 1.0, 0.0],
+                ]
+            ]
+        )
+        targets = torch.tensor([[[0, 1, 2, 3]]])
+        weights = torch.tensor([[[0.0, 1.0, 0.5, 0.0]]])
+
+        extra_numerator, components = model._extra_training_loss(hidden, logits, targets, weights)
+
+        first_ce = torch.logsumexp(torch.tensor([4.5, 1.0]), dim=0) - 1.0
+        second_ce = torch.logsumexp(torch.tensor([7.0, 6.0]), dim=0) - 6.0
+        expected_numerator = first_ce + 0.5 * second_ce
+        self.assertTrue(torch.allclose(extra_numerator, 0.4 * expected_numerator, atol=1e-6))
+        component_numerator, component_denominator = components["selector_loss"]
+        self.assertTrue(torch.allclose(component_numerator, expected_numerator, atol=1e-6))
+        self.assertEqual(component_denominator.item(), 1.5)
+
+        gap_weights = torch.tensor([[[0.0, 1.0, 0.0, 1.0]]])
+        gap_numerator, _ = model._extra_training_loss(hidden, logits, targets, gap_weights)
+        self.assertTrue(torch.allclose(gap_numerator, 0.4 * first_ce, atol=1e-6))
+
+    def test_gradients_reach_convolutions_and_selector(self):
+        torch.manual_seed(13)
+        result = self.model(**_batch(seed=2))
+        self.assertEqual(len(result), 7)
+        loss = result[0]
+        loss_numerator, loss_denominator = result[-1]
+        self.assertTrue(torch.allclose(loss, loss_numerator / loss_denominator.clamp(min=1e-6)))
+        loss.backward()
+
+        draft = self.model.draft_model
+
+        def has_gradient(parameters):
+            return any(
+                parameter.grad is not None and parameter.grad.abs().sum() > 0
+                for parameter in parameters
+            )
+
+        self.assertTrue(has_gradient(draft.layers[0].attention_conv.parameters()))
+        self.assertTrue(has_gradient(draft.layers[0].mlp_conv.parameters()))
+        self.assertGreater(draft.layers[0].attention_conv.base_kernel.grad[1].abs().sum(), 0)
+        self.assertGreater(draft.layers[0].mlp_conv.base_kernel.grad[1].abs().sum(), 0)
+        attention_projection_grad = draft.layers[0].attention_conv.kernel_projection.weight.grad
+        mlp_projection_grad = draft.layers[0].mlp_conv.kernel_projection.weight.grad
+        projection_half = attention_projection_grad.shape[0] // 2
+        self.assertGreater(attention_projection_grad[projection_half:].abs().sum(), 0)
+        self.assertGreater(mlp_projection_grad[projection_half:].abs().sum(), 0)
+        self.assertTrue(has_gradient([draft.candidate_selector.predecessor_codebook]))
+        self.assertTrue(has_gradient([draft.candidate_selector.successor_codebook]))
+        self.assertTrue(has_gradient(draft.candidate_selector.hidden_projection.parameters()))
+        self.assertTrue(has_gradient(draft.context_proj.parameters()))
+        self.assertIsNone(draft.embed_tokens.weight.grad)
+
+    def test_all_masked_batch_has_zero_losses(self):
+        loss, _, _, _, _, components, loss_terms = self.model(**_batch(all_masked=True))
+
+        self.assertEqual(loss.item(), 0.0)
+        self.assertEqual(loss_terms[0].item(), 0.0)
+        self.assertEqual(loss_terms[1].item(), 0.0)
+        selector_numerator, selector_denominator = components["selector_loss"]
+        self.assertEqual(selector_numerator.item(), 0.0)
+        self.assertEqual(selector_denominator.item(), 0.0)
+
+    def test_logit_scale_and_softcap_are_applied(self):
+        self.model.draft_model.config.output_multiplier = 2.0
+        self.model.draft_model.config.final_logit_softcapping = 0.5
+        hidden = torch.tensor([[[1.0] * 16]])
+        lm_head = torch.arange(32 * 16, dtype=torch.float32).reshape(32, 16) / 100
+
+        logits = self.model._compute_logits(hidden, lm_head)
+
+        linear = F.linear(hidden, lm_head) * 2.0
+        self.assertTrue(torch.allclose(logits, torch.tanh(linear / 0.5) * 0.5))
+
+    def test_selector_loss_cannot_be_disabled(self):
+        for alpha in (0.0, float("nan"), float("inf"), float("-inf")):
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(ValueError, "must be positive"):
+                    _make_model(selector_loss_alpha=alpha)
+
+    def test_causal_sliding_mask_truth_table(self):
+        mask = _create_dflash_mask_mod(
+            anchor_positions=torch.tensor([[5]]),
+            block_keep_mask=torch.tensor([[True]]),
+            ctx_len=8,
+            block_size=4,
+            is_causal=True,
+            sliding_window=3,
+        )
+
+        self.assertTrue(mask(0, 0, 0, 4))
+        self.assertFalse(mask(0, 0, 2, 4))
+        self.assertTrue(mask(0, 0, 2, 8))
+        self.assertTrue(mask(0, 0, 2, 10))
+        self.assertFalse(mask(0, 0, 2, 11))
+
+
+class TestDFlash2Export(unittest.TestCase):
+    def test_config_exports_official_dflash2_schema(self):
+        config = _make_config()
+        model = DFlash2DraftModel(config)
+
+        exported = _fixup_export_config(config.to_dict())
+
+        self.assertEqual(exported["model_type"], "qwen3")
+        self.assertEqual(exported["architectures"], ["DFlash2DraftModel"])
+        self.assertEqual(exported["num_target_layers"], 12)
+        self.assertEqual(exported["dflash_config"]["target_layer_ids"], [1, 9])
+        self.assertEqual(exported["dflash_config"]["block_size"], 4)
+        self.assertEqual(exported["dflash_config"]["conv_kernel_size"], 2)
+        self.assertEqual(exported["dflash_config"]["selector_top_k"], 4)
+        self.assertEqual(model.config_for_serving(), exported)
+
+        trainer_class = _load_dflash2_trainer()
+        trainer = trainer_class.__new__(trainer_class)
+        with tempfile.TemporaryDirectory() as output_dir:
+            trainer._write_serving_artifacts(model, model.state_dict(), output_dir)
+            saved_config = json.loads(Path(output_dir, "config.json").read_text())
+            saved_state = torch.load(
+                Path(output_dir, "pytorch_model.bin"),
+                weights_only=True,
+            )
+        self.assertEqual(saved_config, exported)
+        self.assertTrue(torch.equal(saved_state["fc.weight"], model.context_proj.weight))
+
+        raw_without_draft_depth = config.to_dict()
+        target_depth = raw_without_draft_depth["target_num_hidden_layers"]
+        raw_without_draft_depth.pop("num_target_layers")
+        self.assertEqual(
+            _fixup_export_config(raw_without_draft_depth)["num_target_layers"],
+            target_depth,
+        )
+
+    def test_nonunit_embedding_scale_requires_vllm_export(self):
+        config = _make_config()
+        config.input_embedding_scale = 2.0
+        config.dflash_config["input_embedding_scale"] = 2.0
+
+        with self.assertRaisesRegex(ValueError, "input_embedding_scale"):
+            _fixup_export_config(config.to_dict())
+
+        exported = _fixup_export_config(config.to_dict(), export_for_vllm=True)
+        self.assertEqual(exported["dflash_config"]["input_embedding_scale"], 2.0)
+
+    def test_serving_write_errors_reach_every_rank(self):
+        trainer_class = _load_dflash2_trainer()
+        model = DFlash2DraftModel(_make_config())
+
+        for dp_rank, error_type in (
+            (0, OSError),
+            (1, RuntimeError),
+        ):
+            with self.subTest(dp_rank=dp_rank):
+                trainer = trainer_class.__new__(trainer_class)
+                trainer.args = Namespace(fsdp_strategy="FULL_SHARD")
+                trainer.dp_rank = dp_rank
+                trainer.draft_model = model
+                writer = mock.Mock(side_effect=OSError("disk full") if dp_rank == 0 else None)
+
+                def gather_errors(errors, local_error, group=None):
+                    errors[:] = ["OSError: disk full", None]
+
+                method_globals = trainer.save_draft_model_for_serving.__func__.__globals__
+                all_gather = mock.Mock(side_effect=gather_errors)
+                with (
+                    tempfile.TemporaryDirectory() as output_dir,
+                    mock.patch.dict(
+                        method_globals,
+                        {
+                            "get_model_state_dict": mock.Mock(return_value=model.state_dict()),
+                            "get_gloo_group": mock.Mock(return_value=object()),
+                        },
+                    ),
+                    mock.patch.object(method_globals["dist"], "is_initialized", return_value=True),
+                    mock.patch.object(method_globals["dist"], "get_world_size", return_value=2),
+                    mock.patch.object(method_globals["dist"], "all_gather_object", all_gather),
+                    mock.patch.object(trainer, "_write_serving_artifacts", writer),
+                ):
+                    with self.assertRaisesRegex(error_type, "disk full"):
+                        trainer.save_draft_model_for_serving(output_dir)
+
+                all_gather.assert_called_once()
+                self.assertEqual(writer.call_count, 1 if dp_rank == 0 else 0)
+
+    def test_fsdp_conversion_writes_official_serving_artifact(self):
+        model = DFlash2DraftModel(_make_config())
+        source_state = model.state_dict()
+        checkpoint = {
+            f"model_state.model.draft_model.{key}": value for key, value in source_state.items()
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir, "config.json")
+            output_dir = Path(temp_dir, "output")
+            config_path.write_text(json.dumps(model.config.to_dict()))
+            with mock.patch(
+                "tools.convert_to_hf._load_fsdp_state_dict",
+                return_value=checkpoint,
+            ):
+                _convert_fsdp_to_hf(str(config_path), "checkpoint", str(output_dir))
+            saved_state = load_file(str(output_dir / "model.safetensors"))
+
+        remapped = {}
+        for source_key, tensor in source_state.items():
+            if source_key == "embed_tokens.weight":
+                continue
+            target_key = source_key
+            for source_prefix, target_prefix in (
+                ("context_proj.", "fc."),
+                ("context_norm.", "hidden_norm."),
+                ("final_norm.", "norm."),
+            ):
+                if source_key.startswith(source_prefix):
+                    target_key = target_prefix + source_key[len(source_prefix) :]
+                    break
+            remapped[target_key] = tensor
+
+        self.assertEqual(set(saved_state), set(remapped))
+        for key, expected_tensor in remapped.items():
+            with self.subTest(key=key):
+                torch.testing.assert_close(saved_state[key], expected_tensor)
+
+    def test_fsdp_conversion_rejects_incomplete_dflash2_state(self):
+        model = DFlash2DraftModel(_make_config())
+        state = model.state_dict()
+        missing = dict(state)
+        missing.pop(next(iter(missing)))
+        unexpected = dict(state)
+        unexpected["unexpected.weight"] = torch.zeros(1)
+
+        for label, invalid_state in (("missing", missing), ("unexpected", unexpected)):
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temp_dir:
+                config_path = Path(temp_dir, "config.json")
+                output_dir = Path(temp_dir, "output")
+                config_path.write_text(json.dumps(model.config.to_dict()))
+                checkpoint = {
+                    f"model_state.model.draft_model.{key}": value
+                    for key, value in invalid_state.items()
+                }
+                with mock.patch(
+                    "tools.convert_to_hf._load_fsdp_state_dict",
+                    return_value=checkpoint,
+                ):
+                    with self.assertRaises(RuntimeError):
+                        _convert_fsdp_to_hf(str(config_path), "checkpoint", str(output_dir))
+                self.assertFalse(output_dir.exists())
+
+    def test_fsdp_conversion_allows_explicit_embedding_override(self):
+        model = DFlash2DraftModel(_make_config())
+        state = model.state_dict()
+        state.pop("embed_tokens.weight")
+        checkpoint = {f"model_state.model.draft_model.{key}": value for key, value in state.items()}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir, "config.json")
+            output_dir = Path(temp_dir, "output")
+            config_path.write_text(json.dumps(model.config.to_dict()))
+            with (
+                mock.patch(
+                    "tools.convert_to_hf._load_fsdp_state_dict",
+                    return_value=checkpoint,
+                ),
+                mock.patch.object(DFlash2DraftModel, "load_embedding") as load_embedding,
+            ):
+                _convert_fsdp_to_hf(
+                    str(config_path),
+                    "checkpoint",
+                    str(output_dir),
+                    target_model_path="target-model",
+                )
+
+        load_embedding.assert_called_once_with(
+            "target-model", embedding_key="model.embed_tokens.weight"
+        )
+
+    def test_fsdp_conversion_rejects_dflash2_vocab_pruning_before_load(self):
+        model = DFlash2DraftModel(_make_config())
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir, "config.json")
+            config_path.write_text(json.dumps(model.config.to_dict()))
+            loader = mock.Mock()
+            with mock.patch("tools.convert_to_hf._load_fsdp_state_dict", loader):
+                with self.assertRaisesRegex(ValueError, "DFlash2 vocabulary pruning"):
+                    _convert_fsdp_to_hf(
+                        str(config_path),
+                        "checkpoint",
+                        str(Path(temp_dir, "output")),
+                        prune_vocab=True,
+                    )
+            loader.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -58,6 +58,7 @@ from tqdm import tqdm
 from typing_extensions import override
 
 from torchspec.models.draft import AutoDraftModelConfig, AutoEagle3DraftModel
+from torchspec.models.draft.dflash2 import dflash2_config_for_serving
 from torchspec.models.draft.keymap import DRAFT_WEIGHT_KEY_REMAP
 
 logging.basicConfig(
@@ -143,6 +144,7 @@ def _remap_weight_keys(tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tens
 
 
 _MODEL_TYPE_REMAP = {
+    "qwen3_dflash2": "qwen3",
     "qwen3_dspark": "qwen3",
 }
 
@@ -159,6 +161,9 @@ def _fixup_export_config(raw_config: dict, export_for_vllm: bool = False) -> dic
         eagle_cfg = config.get("eagle_config")
         if eagle_cfg and key in eagle_cfg:
             eagle_cfg[key] = [x + 1 for x in eagle_cfg[key]]
+
+    if config.get("architectures") == ["DFlash2DraftModel"]:
+        config = dflash2_config_for_serving(config, export_for_vllm=export_for_vllm)
 
     if config["model_type"] in _MODEL_TYPE_REMAP:
         config["model_type"] = _MODEL_TYPE_REMAP[config["model_type"]]
@@ -256,6 +261,9 @@ def _extract_model_weights(
 
 def _prepare_export_tensors(hf_model) -> dict[str, torch.Tensor]:
     tensors = hf_model.state_dict()
+    if hasattr(hf_model, "state_dict_for_serving"):
+        logger.info("Exporting serving checkpoint keys")
+        return hf_model.state_dict_for_serving(tensors)
     logger.info("Exporting native checkpoint keys")
     return _remap_weight_keys(tensors)
 
@@ -264,6 +272,7 @@ def _save_without_vocab_pruning(
     hf_model, output_dir: str, raw_config: dict, vocab_size: int, export_for_vllm: bool = False
 ) -> None:
     version = _get_torchspec_version()
+    export_config = _fixup_export_config(raw_config, export_for_vllm=export_for_vllm)
     tensors = _prepare_export_tensors(hf_model)
     save_file(
         tensors,
@@ -271,7 +280,6 @@ def _save_without_vocab_pruning(
         metadata={"torchspec_version": version},
     )
 
-    export_config = _fixup_export_config(raw_config, export_for_vllm=export_for_vllm)
     export_config["draft_vocab_size"] = vocab_size
     export_config["_torchspec_version"] = version
     actual_dtype = next(iter(tensors.values())).dtype
@@ -473,6 +481,13 @@ def _convert_fsdp_to_hf(
     max_seq_length: int = 32768,
     cache_dir: Optional[str] = None,
 ) -> None:
+    config = AutoDraftModelConfig.from_file(config_path)
+    if prune_vocab and config.model_type == "qwen3_dflash2":
+        raise ValueError(
+            "DFlash2 vocabulary pruning is not supported because selector codebooks "
+            "use target-vocabulary token IDs."
+        )
+
     logger.info("Loading FSDP model from %s", input_dir)
     t = time.time()
     state_dict = _load_fsdp_state_dict(input_dir)
@@ -485,7 +500,6 @@ def _convert_fsdp_to_hf(
             "Please pass the checkpoint directory (e.g. iter_xxx or iter_xxx/model)."
         )
 
-    config = AutoDraftModelConfig.from_file(config_path)
     hf_model = AutoEagle3DraftModel.from_config(config)
 
     ckpt_dtype = Counter(v.dtype for v in model_state.values()).most_common(1)[0][0]
@@ -493,11 +507,21 @@ def _convert_fsdp_to_hf(
     logger.info("Checkpoint dtype: %s, output dtype: %s", ckpt_dtype, final_dtype)
     hf_model = hf_model.to(ckpt_dtype)
 
-    missing, unexpected = hf_model.load_state_dict(model_state, strict=False)
-    if missing:
-        logger.warning("Missing keys: %s", missing)
-    if unexpected:
-        logger.warning("Unexpected keys: %s", unexpected)
+    if config.model_type == "qwen3_dflash2":
+        missing, unexpected = hf_model.load_state_dict(model_state, strict=False)
+        allowed_missing = {"embed_tokens.weight"} if target_model_path else set()
+        invalid_missing = sorted(set(missing) - allowed_missing)
+        if invalid_missing or unexpected:
+            raise RuntimeError(
+                "DFlash2 checkpoint state does not match the configured model: "
+                f"missing={invalid_missing}, unexpected={sorted(unexpected)}"
+            )
+    else:
+        missing, unexpected = hf_model.load_state_dict(model_state, strict=False)
+        if missing:
+            logger.warning("Missing keys: %s", missing)
+        if unexpected:
+            logger.warning("Unexpected keys: %s", unexpected)
 
     # Optionally override embed_tokens from target model.
     # Useful for older checkpoints where embed_tokens may not have been saved correctly.

--- a/torchspec/__init__.py
+++ b/torchspec/__init__.py
@@ -22,8 +22,10 @@
 
 from torchspec.models import Eagle3Model
 from torchspec.models.dflash import DFlashModel
+from torchspec.models.dflash2 import DFlash2Model
 from torchspec.models.draft import AutoDraftModelConfig, AutoEagle3DraftModel
 from torchspec.models.draft.dflash import DFlashConfig, DFlashDraftModel
+from torchspec.models.draft.dflash2 import DFlash2Config, DFlash2DraftModel
 from torchspec.models.draft.dspark import DSparkConfig, DSparkDraftModel
 from torchspec.models.dspark import DSparkModel
 
@@ -32,6 +34,9 @@ __all__ = [
     "DFlashModel",
     "DFlashConfig",
     "DFlashDraftModel",
+    "DFlash2Model",
+    "DFlash2Config",
+    "DFlash2DraftModel",
     "DSparkModel",
     "DSparkConfig",
     "DSparkDraftModel",

--- a/torchspec/config/dflash2_draft_config.json
+++ b/torchspec/config/dflash2_draft_config.json
@@ -1,0 +1,34 @@
+{
+    "architectures": ["DFlash2DraftModel"],
+    "model_type": "qwen3_dflash2",
+    "attention_bias": false,
+    "attention_dropout": 0.0,
+    "hidden_size": 4096,
+    "intermediate_size": 12288,
+    "num_hidden_layers": 5,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "vocab_size": 151936,
+    "rms_norm_eps": 1e-6,
+    "max_position_embeddings": 40960,
+    "rope_theta": 1000000.0,
+    "num_target_layers": 36,
+    "layer_types": [
+        "full_attention",
+        "full_attention",
+        "full_attention",
+        "full_attention",
+        "full_attention"
+    ],
+    "is_causal": false,
+    "dflash_config": {
+        "block_size": 8,
+        "conv_kernel_size": 2,
+        "conv_group_size": 16,
+        "selector_rank": 256,
+        "selector_top_k": 16,
+        "target_layer_ids": [1, 9, 17, 25, 33],
+        "mask_token_id": 151669
+    },
+    "tie_word_embeddings": false
+}

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -160,6 +160,9 @@ class TrainingConfig:
     dflash_num_anchors: int = 512
     dflash_num_target_layers: int = 5
 
+    # DFlash2-specific parameters (used by DFlash2 trainer only)
+    dflash2_selector_loss_alpha: float = 1.0
+
     # DSpark-specific parameters (used by DSpark trainer only)
     dspark_num_anchors: int = 512
     dspark_num_target_layers: int = 5

--- a/torchspec/models/__init__.py
+++ b/torchspec/models/__init__.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 from torchspec.models.dflash import DFlashModel
+from torchspec.models.dflash2 import DFlash2Model
 from torchspec.models.dspark import DSparkModel
 from torchspec.models.eagle3 import (
     Eagle3Model,
@@ -31,6 +32,7 @@ from torchspec.models.ops.loss_mask import compute_assistant_loss_mask
 __all__ = [
     "Eagle3Model",
     "DFlashModel",
+    "DFlash2Model",
     "DSparkModel",
     "compute_lazy_target_padded",
     "compute_target_p_padded",

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -58,6 +58,8 @@ def _create_dflash_mask_mod(
     block_keep_mask: torch.Tensor,
     ctx_len: int,
     block_size: int,
+    is_causal: bool = False,
+    sliding_window: int | None = None,
 ):
     """Create a mask_mod function for DFlash block-causal attention.
 
@@ -66,7 +68,7 @@ def _create_dflash_mask_mod(
 
     Rules:
       1. Each block sees context strictly before its anchor (kv_idx < anchor_pos)
-      2. Intra-block attention is bidirectional (per SpecForge PR #427)
+      2. Intra-block attention follows is_causal and sliding_window
       3. Different blocks are invisible to each other
       4. Invalid blocks (block_keep_mask=False) see nothing
     """
@@ -82,6 +84,17 @@ def _create_dflash_mask_mod(
         is_draft = kv_idx >= ctx_len
         kv_block_id = (kv_idx - ctx_len) // block_size
         mask_draft = is_draft & (q_block_id == kv_block_id)
+
+        q_offset = q_idx % block_size
+        kv_offset = (kv_idx - ctx_len) % block_size
+        if is_causal:
+            mask_draft = mask_draft & (kv_offset <= q_offset)
+        if sliding_window is not None:
+            query_position = anchor_pos + q_offset
+            mask_context = mask_context & (query_position - kv_idx < sliding_window)
+            mask_draft = mask_draft & (
+                abs(query_position - (anchor_pos + kv_offset)) < sliding_window
+            )
 
         is_valid_block = block_keep_mask[b, q_block_id]
         return (mask_context | mask_draft) & is_valid_block
@@ -251,6 +264,27 @@ class DFlashModel(nn.Module):
 
         return self.draft_model.embed_tokens(noise_ids)
 
+    def _block_mask_options(self) -> dict:
+        return {}
+
+    def _compute_logits(
+        self,
+        draft_hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        if hasattr(self.draft_model, "lm_head"):
+            return self.draft_model.lm_head(draft_hidden)
+        return F.linear(draft_hidden, lm_head_weight)
+
+    def _extra_training_loss(
+        self,
+        draft_hidden: torch.Tensor,
+        logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        objective_weights: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict]:
+        return logits.new_zeros(()), {}
+
     def _draft_backbone(
         self,
         input_ids: torch.Tensor,
@@ -302,6 +336,7 @@ class DFlashModel(nn.Module):
                 block_keep_mask=block_keep_mask,
                 ctx_len=seq_len,
                 block_size=self.block_size,
+                **self._block_mask_options(),
             )
             block_mask = compile_friendly_create_block_mask(
                 mask_mod=mask_mod,
@@ -367,11 +402,7 @@ class DFlashModel(nn.Module):
         )
 
         # 7. Compute logits via frozen LM head
-        logits = (
-            self.draft_model.lm_head(draft_hidden)
-            if hasattr(self.draft_model, "lm_head")
-            else F.linear(draft_hidden, lm_head_weight)
-        )
+        logits = self._compute_logits(draft_hidden, lm_head_weight)
 
         # 8. Compute labels and weight mask (SpecForge pattern)
         # Labels: same-position prediction (position k predicts token at anchor+k)
@@ -458,6 +489,13 @@ class DFlashModel(nn.Module):
         flat_weights = objective_weights.view(-1)
         loss_numerator = (loss_per_token * flat_weights).sum()
         loss_denominator = flat_weights.sum()
+        extra_numerator, loss_components = self._extra_training_loss(
+            draft_hidden=draft_hidden,
+            logits=logits,
+            target_ids=target_ids,
+            objective_weights=objective_weights,
+        )
+        loss_numerator = loss_numerator + extra_numerator
         loss = loss_numerator / loss_denominator.clamp(min=1e-6)
 
         # 10. Accuracy (using binary mask without decay)
@@ -481,7 +519,6 @@ class DFlashModel(nn.Module):
                 dim=(0, 1)
             ) / count_per_pos
 
-        loss_components = {}
         return (
             loss,
             accuracy,

--- a/torchspec/models/dflash2.py
+++ b/torchspec/models/dflash2.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DFlash2 training wrapper."""
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+from torchspec.models.dflash import DFlashModel
+
+
+class DFlash2Model(DFlashModel):
+    def __init__(self, *args, selector_loss_alpha: float = 1.0, **kwargs):
+        super().__init__(*args, **kwargs)
+        selector_loss_alpha = float(selector_loss_alpha)
+        if not math.isfinite(selector_loss_alpha) or selector_loss_alpha <= 0:
+            raise ValueError(
+                f"dflash2_selector_loss_alpha must be positive, got {selector_loss_alpha}"
+            )
+        self.selector_loss_alpha = selector_loss_alpha
+
+        config = self.draft_model.config
+        layer_types = list(getattr(config, "layer_types", []) or [])
+        if layer_types and len(layer_types) != config.num_hidden_layers:
+            raise ValueError(
+                "DFlash2 layer_types must contain one entry per draft layer, got "
+                f"{len(layer_types)} for {config.num_hidden_layers} layers"
+            )
+        attention_types = set(layer_types or ["full_attention"])
+        if not attention_types <= {"full_attention", "sliding_attention"}:
+            raise ValueError(f"Unsupported DFlash2 layer types: {sorted(attention_types)}")
+        if len(attention_types) > 1:
+            raise ValueError("DFlash2 training does not support mixed full and sliding layers")
+
+        uses_sliding_window = "sliding_attention" in attention_types
+        explicit_causality = getattr(config, "is_causal", None)
+        self.attention_is_causal = (
+            uses_sliding_window if explicit_causality is None else bool(explicit_causality)
+        )
+        configured_window = getattr(config, "sliding_window", None)
+        self.sliding_window = (
+            int(configured_window)
+            if uses_sliding_window and configured_window is not None
+            else None
+        )
+        if self.sliding_window is not None and self.sliding_window < 1:
+            raise ValueError(f"sliding_window must be positive, got {self.sliding_window}")
+
+    def _block_mask_options(self) -> dict:
+        return {
+            "is_causal": self.attention_is_causal,
+            "sliding_window": self.sliding_window,
+        }
+
+    def _compute_logits(
+        self,
+        draft_hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        logits = super()._compute_logits(draft_hidden, lm_head_weight)
+        logits = logits * self.draft_model.config.output_multiplier
+        softcap = self.draft_model.config.final_logit_softcapping
+        if softcap is not None and softcap > 0:
+            logits = torch.tanh(logits / softcap) * softcap
+        return logits
+
+    def _extra_training_loss(
+        self,
+        draft_hidden: torch.Tensor,
+        logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        objective_weights: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict]:
+        batch, num_blocks, block_size = target_ids.shape
+        hidden = draft_hidden.reshape(batch, num_blocks, block_size, -1)[..., 1:, :]
+        unary_logits = logits.reshape(batch, num_blocks, block_size, -1)[..., 1:, :]
+        predecessor_ids = target_ids[..., :-1]
+        successor_ids = target_ids[..., 1:]
+
+        scores, candidate_ids = self.draft_model.candidate_selector.score_candidates(
+            hidden,
+            unary_logits,
+            predecessor_ids,
+            training_successor_ids=successor_ids,
+        )
+        matches = candidate_ids == successor_ids.unsqueeze(-1)
+        eligible_weights = objective_weights[..., 1:]
+        eligible_weights = eligible_weights * (eligible_weights > 0).cumprod(dim=-1)
+        target_indices = matches.to(torch.int64).argmax(dim=-1)
+        selector_ce = F.cross_entropy(
+            scores.reshape(-1, scores.shape[-1]),
+            target_indices.reshape(-1),
+            reduction="none",
+        ).reshape_as(eligible_weights)
+        selector_num = (selector_ce * eligible_weights).sum()
+        selector_den = eligible_weights.sum().detach()
+        return self.selector_loss_alpha * selector_num, {
+            "selector_loss": (selector_num.detach(), selector_den),
+        }

--- a/torchspec/models/draft/__init__.py
+++ b/torchspec/models/draft/__init__.py
@@ -22,6 +22,7 @@ from torchspec.models.draft.auto import AutoDraftModelConfig, AutoEagle3DraftMod
 from torchspec.models.draft.base import Eagle3DraftModel
 from torchspec.models.draft.deepseek_eagle import Eagle3DeepseekV2ForCausalLM
 from torchspec.models.draft.dflash import DFlashConfig, DFlashDraftModel
+from torchspec.models.draft.dflash2 import DFlash2Config, DFlash2DraftModel
 from torchspec.models.draft.dspark import DSparkConfig, DSparkDraftModel
 from torchspec.models.draft.llama3_eagle import LlamaForCausalLMEagle3
 
@@ -32,6 +33,8 @@ __all__ = [
     "Eagle3DraftModel",
     "DFlashConfig",
     "DFlashDraftModel",
+    "DFlash2Config",
+    "DFlash2DraftModel",
     "DSparkConfig",
     "DSparkDraftModel",
     "LlamaForCausalLMEagle3",

--- a/torchspec/models/draft/auto.py
+++ b/torchspec/models/draft/auto.py
@@ -28,6 +28,7 @@ from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3
 
 from torchspec.models.draft.deepseek_eagle import Eagle3DeepseekV2ForCausalLM
 from torchspec.models.draft.dflash import DFlashConfig, DFlashDraftModel
+from torchspec.models.draft.dflash2 import DFlash2Config, DFlash2DraftModel
 from torchspec.models.draft.dspark import (
     DSparkConfig,
     DSparkDraftModel,
@@ -43,6 +44,7 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
         LlamaConfig: LlamaForCausalLMEagle3,
         DeepseekV3Config: Eagle3DeepseekV2ForCausalLM,
         DFlashConfig: DFlashDraftModel,
+        DFlash2Config: DFlash2DraftModel,
         DSparkConfig: DSparkDraftModel,
         K3DSparkConfig: K3DSparkModel,
     }
@@ -85,6 +87,7 @@ class AutoDraftModelConfig:
         "LlamaForCausalLMEagle3": LlamaConfig,
         "Eagle3DeepseekV2ForCausalLM": DeepseekV3Config,
         "DFlashDraftModel": DFlashConfig,
+        "DFlash2DraftModel": DFlash2Config,
         "Qwen3DSparkModel": DSparkConfig,
         "DSparkDraftModel": DSparkConfig,
         "K3DSparkModel": K3DSparkConfig,

--- a/torchspec/models/draft/dflash2.py
+++ b/torchspec/models/draft/dflash2.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DFlash2 draft model adapted from z-lab/dflash at revision 07ebd93.
+
+Source: https://github.com/z-lab/dflash/tree/07ebd93db9f472af339b644bb70221ad8428328a
+"""
+
+import json
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torchspec.models.draft.dflash import (
+    DFlashConfig,
+    DFlashDecoderLayer,
+    DFlashDraftModel,
+    build_target_layer_ids,
+)
+
+_SERVING_KEY_REMAP = (
+    ("context_proj.", "fc."),
+    ("context_norm.", "hidden_norm."),
+    ("final_norm.", "norm."),
+)
+
+_NESTED_CONFIG_FIELDS = (
+    "block_size",
+    "conv_group_size",
+    "conv_kernel_size",
+    "final_logit_softcapping",
+    "input_embedding_scale",
+    "mask_token_id",
+    "output_multiplier",
+    "selector_rank",
+    "selector_top_k",
+    "target_layer_ids",
+)
+
+
+def dflash2_config_for_serving(raw_config: dict, *, export_for_vllm: bool = False) -> dict:
+    config = json.loads(json.dumps(raw_config))
+    dflash_config = dict(config.get("dflash_config") or {})
+    for key in _NESTED_CONFIG_FIELDS:
+        if key in config and key not in dflash_config:
+            dflash_config[key] = config[key]
+        config.pop(key, None)
+    config["dflash_config"] = dflash_config
+    target_num_hidden_layers = config.pop("target_num_hidden_layers", None)
+    if target_num_hidden_layers is not None:
+        config["num_target_layers"] = target_num_hidden_layers
+    if not export_for_vllm and float(dflash_config.get("input_embedding_scale", 1.0)) != 1.0:
+        raise ValueError("SGLang DFlash2 export requires input_embedding_scale=1.0")
+    config.pop("target_hidden_size", None)
+    config["model_type"] = "qwen3"
+    return config
+
+
+def dflash2_state_dict_for_serving(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    remapped = {}
+    for key, value in state_dict.items():
+        if key == "embed_tokens.weight":
+            continue
+        new_key = key
+        for old_prefix, new_prefix in _SERVING_KEY_REMAP:
+            if key.startswith(old_prefix):
+                new_key = new_prefix + key[len(old_prefix) :]
+                break
+        remapped[new_key] = value
+    return remapped
+
+
+class DFlash2Config(DFlashConfig):
+    model_type = "qwen3_dflash2"
+
+    def __init__(
+        self,
+        block_size: int = 16,
+        conv_kernel_size: int = 2,
+        conv_group_size: int = 16,
+        selector_rank: int = 256,
+        selector_top_k: int = 16,
+        input_embedding_scale: float = 1.0,
+        output_multiplier: float = 1.0,
+        final_logit_softcapping: float | None = None,
+        dflash_config: dict | None = None,
+        **kwargs,
+    ):
+        nested = dict(dflash_config or {})
+        model_type = kwargs.get("model_type")
+        if model_type not in (None, "qwen3", "qwen3_dflash2"):
+            raise ValueError(
+                f"DFlash2 model_type must be 'qwen3' or 'qwen3_dflash2', got {model_type!r}"
+            )
+
+        block_size = int(nested.get("block_size", block_size))
+        conv_kernel_size = int(nested.get("conv_kernel_size", conv_kernel_size))
+        conv_group_size = int(nested.get("conv_group_size", conv_group_size))
+        selector_rank = int(nested.get("selector_rank", selector_rank))
+        selector_top_k = int(nested.get("selector_top_k", selector_top_k))
+        input_embedding_scale = float(nested.get("input_embedding_scale", input_embedding_scale))
+        output_multiplier = float(nested.get("output_multiplier", output_multiplier))
+        final_logit_softcapping = nested.get("final_logit_softcapping", final_logit_softcapping)
+        if final_logit_softcapping is not None:
+            final_logit_softcapping = float(final_logit_softcapping)
+            if final_logit_softcapping == 0.0:
+                final_logit_softcapping = None
+
+        nested_target_layer_ids = nested.get("target_layer_ids")
+        target_layer_ids = (
+            nested_target_layer_ids
+            if nested_target_layer_ids is not None
+            else kwargs.get("target_layer_ids")
+        )
+        if target_layer_ids is None:
+            target_depth = int(
+                kwargs.get("target_num_hidden_layers", kwargs.get("num_target_layers", 36))
+            )
+            draft_depth = int(kwargs.get("num_hidden_layers", 5))
+            target_layer_ids = build_target_layer_ids(draft_depth, target_depth)
+            kwargs["target_num_hidden_layers"] = target_depth
+            kwargs["num_target_layers"] = draft_depth
+            kwargs["target_layer_ids"] = target_layer_ids
+        else:
+            target_layer_ids = [int(layer_id) for layer_id in target_layer_ids]
+            target_depth = kwargs.get("num_target_layers")
+            if (
+                kwargs.get("target_num_hidden_layers") is None
+                and target_depth is not None
+                and (
+                    nested_target_layer_ids is not None
+                    or int(target_depth) != len(target_layer_ids)
+                )
+            ):
+                kwargs["target_num_hidden_layers"] = int(target_depth)
+            kwargs["num_target_layers"] = len(target_layer_ids)
+            kwargs["target_layer_ids"] = target_layer_ids
+
+        if not target_layer_ids:
+            raise ValueError("target_layer_ids must contain at least one layer")
+        target_depth = int(kwargs.get("target_num_hidden_layers", 36))
+        invalid_layer_ids = [
+            layer_id for layer_id in target_layer_ids if not 0 <= layer_id < target_depth
+        ]
+        if invalid_layer_ids:
+            raise ValueError(
+                f"target_layer_ids must be in [0, {target_depth}), got {invalid_layer_ids}"
+            )
+
+        hidden_size = int(kwargs.get("hidden_size", 4096))
+        target_hidden_size = kwargs.get("target_hidden_size")
+        if target_hidden_size is None:
+            target_hidden_size = hidden_size
+        if target_hidden_size != hidden_size:
+            raise ValueError(
+                "DFlash2 target_hidden_size must equal hidden_size, "
+                f"got {target_hidden_size} and {hidden_size}"
+            )
+        kwargs["target_hidden_size"] = hidden_size
+        kwargs["mask_token_id"] = int(
+            nested.get("mask_token_id", kwargs.get("mask_token_id", 151669))
+        )
+        rope_parameters = kwargs.get("rope_parameters") or {}
+        kwargs.setdefault("rope_theta", rope_parameters.get("rope_theta", 10000.0))
+        kwargs.pop("model_type", None)
+
+        hidden_act = kwargs.get("hidden_act", "silu")
+        if hidden_act != "silu":
+            raise ValueError(f"DFlash2 training requires hidden_act='silu', got {hidden_act!r}")
+        if kwargs.get("attention_bias", False):
+            raise ValueError("DFlash2 training does not support attention_bias=True")
+        if float(kwargs.get("attention_dropout", 0.0)) != 0.0:
+            raise ValueError("DFlash2 training requires attention_dropout=0")
+        if kwargs.get("fc_norm", False):
+            raise ValueError("DFlash2 training does not support fc_norm=True")
+        if kwargs.get("rope_scaling") is not None:
+            raise ValueError("DFlash2 training does not support rope_scaling")
+        unsupported_rope_keys = set(rope_parameters) - {"rope_theta", "rope_type"}
+        if rope_parameters.get("rope_type", "default") != "default" or unsupported_rope_keys:
+            raise ValueError("DFlash2 training supports only default rope_parameters")
+
+        num_hidden_layers = int(kwargs.get("num_hidden_layers", 5))
+        use_sliding_window = bool(kwargs.get("use_sliding_window", False))
+        sliding_window = kwargs.get("sliding_window")
+        layer_types = kwargs.get("layer_types")
+        if layer_types is None:
+            if use_sliding_window and sliding_window is None:
+                raise ValueError(
+                    "DFlash2 use_sliding_window requires an explicit positive sliding_window"
+                )
+            max_window_layers = int(kwargs.get("max_window_layers", 28))
+            layer_types = [
+                "sliding_attention"
+                if use_sliding_window and layer_id >= max_window_layers
+                else "full_attention"
+                for layer_id in range(num_hidden_layers)
+            ]
+        else:
+            layer_types = list(layer_types)
+        if len(layer_types) != num_hidden_layers:
+            raise ValueError(
+                "DFlash2 layer_types must contain one entry per draft layer, got "
+                f"{len(layer_types)} for {num_hidden_layers} layers"
+            )
+        attention_types = set(layer_types)
+        if not attention_types <= {"full_attention", "sliding_attention"}:
+            raise ValueError(f"Unsupported DFlash2 layer types: {sorted(attention_types)}")
+        if len(attention_types) > 1:
+            raise ValueError("DFlash2 training does not support mixed full and sliding layers")
+        if "sliding_attention" in attention_types:
+            if sliding_window is None:
+                raise ValueError(
+                    "DFlash2 sliding_attention layers require an explicit positive sliding_window"
+                )
+            sliding_window = int(sliding_window)
+            if sliding_window < 1:
+                raise ValueError(f"sliding_window must be positive, got {sliding_window}")
+        else:
+            sliding_window = None
+        kwargs["layer_types"] = layer_types
+        kwargs["sliding_window"] = sliding_window
+
+        if block_size < 2:
+            raise ValueError(f"block_size must be at least 2, got {block_size}")
+        if not 1 <= conv_kernel_size <= block_size:
+            raise ValueError(
+                f"conv_kernel_size must be in [1, block_size={block_size}], got {conv_kernel_size}"
+            )
+        if conv_group_size < 1 or hidden_size % conv_group_size:
+            raise ValueError(
+                f"conv_group_size={conv_group_size} must divide hidden_size={hidden_size}"
+            )
+        vocab_size = int(kwargs.get("vocab_size", 152064))
+        if not 0 <= kwargs["mask_token_id"] < vocab_size:
+            raise ValueError(
+                f"mask_token_id must be in [0, {vocab_size}), got {kwargs['mask_token_id']}"
+            )
+        draft_vocab_size = kwargs.get("draft_vocab_size")
+        if draft_vocab_size is not None and int(draft_vocab_size) != vocab_size:
+            raise ValueError("DFlash2 does not support draft_vocab_size different from vocab_size")
+        if selector_rank < 1:
+            raise ValueError(f"selector_rank must be positive, got {selector_rank}")
+        if not 2 <= selector_top_k <= vocab_size:
+            raise ValueError(f"selector_top_k must be in [2, {vocab_size}], got {selector_top_k}")
+        if not math.isfinite(input_embedding_scale) or input_embedding_scale <= 0:
+            raise ValueError(f"input_embedding_scale must be positive, got {input_embedding_scale}")
+        if not math.isfinite(output_multiplier) or output_multiplier <= 0:
+            raise ValueError(f"output_multiplier must be positive, got {output_multiplier}")
+        if final_logit_softcapping is not None and (
+            not math.isfinite(final_logit_softcapping) or final_logit_softcapping < 0
+        ):
+            raise ValueError(
+                f"final_logit_softcapping must be positive, got {final_logit_softcapping}"
+            )
+
+        super().__init__(**kwargs)
+        self.block_size = block_size
+        self.conv_kernel_size = conv_kernel_size
+        self.conv_group_size = conv_group_size
+        self.selector_rank = selector_rank
+        self.selector_top_k = selector_top_k
+        self.input_embedding_scale = input_embedding_scale
+        self.output_multiplier = output_multiplier
+        self.final_logit_softcapping = final_logit_softcapping
+
+        nested.update(
+            {
+                "block_size": self.block_size,
+                "conv_kernel_size": self.conv_kernel_size,
+                "conv_group_size": self.conv_group_size,
+                "selector_rank": self.selector_rank,
+                "selector_top_k": self.selector_top_k,
+                "mask_token_id": self.mask_token_id,
+                "target_layer_ids": self.target_layer_ids,
+            }
+        )
+        if self.input_embedding_scale != 1.0:
+            nested["input_embedding_scale"] = self.input_embedding_scale
+        if self.output_multiplier != 1.0:
+            nested["output_multiplier"] = self.output_multiplier
+        if self.final_logit_softcapping is not None:
+            nested["final_logit_softcapping"] = self.final_logit_softcapping
+        self.dflash_config = nested
+
+
+class DFlashGroupedConv(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        block_size: int,
+        kernel_size: int,
+        group_size: int,
+    ):
+        super().__init__()
+        if hidden_size % group_size:
+            raise ValueError(f"group_size={group_size} must divide hidden_size={hidden_size}")
+        self.block_size = int(block_size)
+        self.kernel_size = int(kernel_size)
+        self.group_size = int(group_size)
+        self.num_groups = int(hidden_size) // self.group_size
+
+        base_kernel = torch.zeros(2, self.kernel_size, hidden_size)
+        base_kernel[:, 0] = 1.0
+        self.base_kernel = nn.Parameter(base_kernel)
+        self.kernel_projection = nn.Linear(
+            hidden_size,
+            2 * self.kernel_size * self.num_groups,
+            bias=False,
+        )
+        nn.init.zeros_(self.kernel_projection.weight)
+
+    def _convolve(
+        self,
+        hidden_states: torch.Tensor,
+        dynamic_kernel: torch.Tensor,
+        side: int,
+    ) -> torch.Tensor:
+        batch, length, hidden_size = hidden_states.shape
+        if length % self.block_size:
+            raise ValueError(
+                f"draft length {length} must be divisible by block_size={self.block_size}"
+            )
+
+        blocks = hidden_states.reshape(-1, self.block_size, self.num_groups, self.group_size)
+        dynamic = dynamic_kernel.reshape(-1, self.block_size, self.kernel_size, self.num_groups)
+        base = self.base_kernel[side].reshape(
+            1, 1, self.kernel_size, self.num_groups, self.group_size
+        )
+        coefficients = base.to(hidden_states.dtype) + dynamic.unsqueeze(-1)
+
+        output = torch.zeros_like(blocks)
+        for offset in range(self.kernel_size):
+            values = blocks if offset == 0 else F.pad(blocks[:, :-offset], (0, 0, 0, 0, offset, 0))
+            output = output + coefficients[:, :, offset] * values
+        return output.reshape(batch, length, hidden_size)
+
+    def prepare(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        dynamic = self.kernel_projection(hidden_states).reshape(
+            *hidden_states.shape[:-1],
+            2,
+            self.kernel_size,
+            self.num_groups,
+        )
+        return self._convolve(hidden_states, dynamic[..., 0, :, :], 0), dynamic[..., 1, :, :]
+
+    def finish(
+        self,
+        hidden_states: torch.Tensor,
+        dynamic_kernel: torch.Tensor,
+    ) -> torch.Tensor:
+        return self._convolve(hidden_states, dynamic_kernel, 1)
+
+
+class CandidateSelector(nn.Module):
+    def __init__(self, hidden_size: int, vocab_size: int, rank: int, top_k: int):
+        super().__init__()
+        if not 2 <= top_k <= vocab_size:
+            raise ValueError(f"top_k must be in [2, {vocab_size}], got {top_k}")
+        self.top_k = int(top_k)
+        self.predecessor_codebook = nn.Parameter(torch.empty(vocab_size, rank))
+        self.successor_codebook = nn.Parameter(torch.empty(vocab_size, rank))
+        self.hidden_projection = nn.Linear(hidden_size, rank, bias=False)
+        nn.init.normal_(self.predecessor_codebook, std=0.02)
+        nn.init.normal_(self.successor_codebook, std=0.02)
+
+    def score_candidates(
+        self,
+        hidden_states: torch.Tensor,
+        logits: torch.Tensor,
+        predecessor_ids: torch.Tensor,
+        *,
+        training_successor_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        unary_logits, candidate_ids = torch.topk(logits, self.top_k, dim=-1, sorted=False)
+        if training_successor_ids is not None:
+            matches = candidate_ids == training_successor_ids.unsqueeze(-1)
+            missing = ~matches.any(dim=-1)
+            replace_at = unary_logits.argmin(dim=-1, keepdim=True)
+            current_ids = candidate_ids.gather(-1, replace_at)
+            current_logits = unary_logits.gather(-1, replace_at)
+            replacement_ids = torch.where(
+                missing.unsqueeze(-1), training_successor_ids.unsqueeze(-1), current_ids
+            )
+            replacement_logits = torch.where(
+                missing.unsqueeze(-1),
+                logits.gather(-1, training_successor_ids.unsqueeze(-1)),
+                current_logits,
+            )
+            candidate_ids = candidate_ids.scatter(-1, replace_at, replacement_ids)
+            unary_logits = unary_logits.scatter(-1, replace_at, replacement_logits)
+        hidden = self.hidden_projection(hidden_states)
+        predecessor = self.predecessor_codebook[predecessor_ids] * hidden
+        successor = self.successor_codebook[candidate_ids]
+        scores = unary_logits + torch.einsum("...r,...kr->...k", predecessor, successor)
+        return scores, candidate_ids
+
+
+class DFlash2DecoderLayer(DFlashDecoderLayer):
+    def __init__(self, config: DFlash2Config):
+        super().__init__(config)
+        conv_args = {
+            "hidden_size": config.hidden_size,
+            "block_size": config.block_size,
+            "kernel_size": config.conv_kernel_size,
+            "group_size": config.conv_group_size,
+        }
+        self.attention_conv = DFlashGroupedConv(**conv_args)
+        self.mlp_conv = DFlashGroupedConv(**conv_args)
+
+    def forward(
+        self,
+        draft_hidden: torch.Tensor,
+        context_hidden: torch.Tensor,
+        draft_position_ids: torch.Tensor,
+        context_position_ids: torch.Tensor,
+        block_mask=None,
+    ) -> torch.Tensor:
+        residual = draft_hidden
+        draft_hidden = self.input_layernorm(draft_hidden)
+        draft_hidden, attention_kernel = self.attention_conv.prepare(draft_hidden)
+        draft_hidden = self.self_attn(
+            draft_hidden=draft_hidden,
+            context_hidden=context_hidden,
+            draft_position_ids=draft_position_ids,
+            context_position_ids=context_position_ids,
+            block_mask=block_mask,
+        )
+        draft_hidden = self.attention_conv.finish(draft_hidden, attention_kernel)
+        draft_hidden = residual + draft_hidden
+
+        residual = draft_hidden
+        draft_hidden = self.post_attention_layernorm(draft_hidden)
+        draft_hidden, mlp_kernel = self.mlp_conv.prepare(draft_hidden)
+        draft_hidden = self.mlp(draft_hidden)
+        draft_hidden = self.mlp_conv.finish(draft_hidden, mlp_kernel)
+        return residual + draft_hidden
+
+
+class DFlash2DraftModel(DFlashDraftModel):
+    config_class = DFlash2Config
+    decoder_layer_class = DFlash2DecoderLayer
+
+    def __init__(self, config: DFlash2Config):
+        super().__init__(config)
+        self.candidate_selector = CandidateSelector(
+            hidden_size=config.hidden_size,
+            vocab_size=config.vocab_size,
+            rank=config.selector_rank,
+            top_k=config.selector_top_k,
+        )
+
+    def config_for_serving(self) -> dict:
+        return dflash2_config_for_serving(self.config.to_dict())
+
+    def state_dict_for_serving(
+        self,
+        state_dict: dict[str, torch.Tensor] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        if state_dict is None:
+            state_dict = self.state_dict()
+        return dflash2_state_dict_for_serving(state_dict)
+
+    def forward(
+        self,
+        draft_input_ids: torch.Tensor | None,
+        context_feature: torch.Tensor,
+        draft_position_ids: torch.Tensor,
+        context_position_ids: torch.Tensor,
+        block_mask=None,
+        noise_embedding: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if noise_embedding is None:
+            noise_embedding = self.embed_tokens(draft_input_ids)
+            draft_input_ids = None
+        noise_embedding = noise_embedding * self.config.input_embedding_scale
+        return super().forward(
+            draft_input_ids=draft_input_ids,
+            context_feature=context_feature,
+            draft_position_ids=draft_position_ids,
+            context_position_ids=context_position_ids,
+            block_mask=block_mask,
+            noise_embedding=noise_embedding,
+        )

--- a/torchspec/train_entry.py
+++ b/torchspec/train_entry.py
@@ -259,20 +259,23 @@ def _get_draft_model_config(args):
 
 
 def _validate_and_configure_dflash(args, draft_model_config) -> None:
-    """Validate
-    -specific config and auto-set aux layer IDs.
+    """Validate DFlash-specific config and auto-set aux layer IDs.
 
     Called before dataset loading to fail fast on misconfigurations.
     """
     from torchspec.models.draft.dflash import DFlashConfig
+    from torchspec.models.draft.dflash2 import DFlash2Config
     from torchspec.models.draft.dspark import DSparkConfig
 
     if not isinstance(draft_model_config, DFlashConfig):
         return
 
-    # DSparkConfig subclasses DFlashConfig
+    is_dflash2 = isinstance(draft_model_config, DFlash2Config)
     is_dspark = isinstance(draft_model_config, DSparkConfig)
-    algo = "DSpark" if is_dspark else "DFlash"
+    algo = "DFlash2" if is_dflash2 else "DSpark" if is_dspark else "DFlash"
+
+    if is_dflash2 and getattr(args, "attention_backend", None) == "usp":
+        raise ValueError("DFlash2 does not support training.attention_backend=usp.")
 
     engine_type = getattr(args, "inference_engine_type", "hf")
     if engine_type not in ("vllm", "sgl", "trtllm", "offline"):
@@ -281,8 +284,20 @@ def _validate_and_configure_dflash(args, draft_model_config) -> None:
             f"('vllm', 'sgl', 'trtllm', 'offline'), got '{engine_type}'."
         )
     if getattr(args, "defer_tokenization", False):
-        raise NotImplementedError("DFlash does not support defer_tokenization=True.")
+        raise NotImplementedError(f"{algo} does not support defer_tokenization=True.")
     block_size = getattr(args, "dflash_block_size", 16)
+    if is_dflash2 and block_size != draft_model_config.block_size:
+        raise ValueError(
+            "training.dflash_block_size must match dflash_config.block_size "
+            f"({block_size} != {draft_model_config.block_size})."
+        )
+    num_target_layers = getattr(args, "dflash_num_target_layers", 5)
+    if is_dflash2 and num_target_layers != draft_model_config.num_target_layers:
+        raise ValueError(
+            "training.dflash_num_target_layers must match the number of "
+            f"dflash_config.target_layer_ids ({num_target_layers} != "
+            f"{draft_model_config.num_target_layers})."
+        )
     min_loss = getattr(args, "min_loss_tokens", 0)
     if min_loss < 2 * block_size:
         raise ValueError(
@@ -290,17 +305,22 @@ def _validate_and_configure_dflash(args, draft_model_config) -> None:
             f"({min_loss} < {2 * block_size}). Set dataset.min_loss_tokens={2 * block_size}."
         )
 
-    # Auto-set aux layer IDs from draft config if not explicitly provided
+    target_layer_ids = getattr(draft_model_config, "target_layer_ids", None)
     if not getattr(args, "aux_hidden_states_layers", None):
         from torchspec.models.draft.dflash import build_target_layer_ids
 
-        target_layer_ids = getattr(draft_model_config, "target_layer_ids", None)
         if target_layer_ids is None:
             num_target = getattr(draft_model_config, "num_target_layers", 5)
             target_num_hidden = getattr(draft_model_config, "target_num_hidden_layers", 36)
             target_layer_ids = build_target_layer_ids(num_target, target_num_hidden)
         args.aux_hidden_states_layers = target_layer_ids
-        logger.info(f"DFlash: set aux_hidden_states_layers = {target_layer_ids}")
+        logger.info(f"{algo}: set aux_hidden_states_layers = {target_layer_ids}")
+    elif is_dflash2 and list(args.aux_hidden_states_layers) != list(target_layer_ids):
+        raise ValueError(
+            "inference.aux_hidden_states_layers must match "
+            f"dflash_config.target_layer_ids ({list(args.aux_hidden_states_layers)} != "
+            f"{list(target_layer_ids)})."
+        )
 
 
 def train_async_no_generation(args):

--- a/torchspec/training/dflash2_trainer.py
+++ b/torchspec/training/dflash2_trainer.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DFlash2 trainer."""
+
+from argparse import Namespace
+
+from torchspec.models.dflash2 import DFlash2Model
+from torchspec.models.draft.dflash2 import DFlash2Config, DFlash2DraftModel
+from torchspec.training.dflash_trainer import DFlashTrainer
+
+
+class DFlash2Trainer(DFlashTrainer):
+    _draft_config_class = DFlash2Config
+    _extra_loss_component_keys = ["selector_loss"]
+
+    def __init__(self, args: Namespace):
+        super().__init__(args)
+        self.selector_loss_alpha = getattr(args, "dflash2_selector_loss_alpha", 1.0)
+
+    def _build_draft_model(self, config):
+        if config.block_size != self.block_size:
+            raise ValueError(
+                "training.dflash_block_size must match dflash_config.block_size "
+                f"({self.block_size} != {config.block_size})"
+            )
+        if config.num_target_layers != self.num_target_layers:
+            raise ValueError(
+                "training.dflash_num_target_layers must match the number of "
+                f"dflash_config.target_layer_ids ({self.num_target_layers} != "
+                f"{config.num_target_layers})"
+            )
+        return DFlash2DraftModel(config)
+
+    def _build_training_wrapper(self, draft_model):
+        return DFlash2Model(
+            draft_model=draft_model,
+            block_size=self.block_size,
+            num_anchors=self.num_anchors,
+            loss_objective=self.loss_objective,
+            dpace_alpha=self.dpace_alpha,
+            loss_decay_gamma=self.loss_decay_gamma,
+            ce_loss_alpha=self.ce_loss_alpha,
+            l1_loss_alpha=self.l1_loss_alpha,
+            selector_loss_alpha=self.selector_loss_alpha,
+        )

--- a/torchspec/training/optimizer.py
+++ b/torchspec/training/optimizer.py
@@ -20,9 +20,21 @@
 
 import torch
 import torch.distributed as dist
+from torch.distributed.tensor import DTensor
 
 from torchspec.training.lr_scheduler import LRSchedulerWithWarmup
 from torchspec.utils.logging import print_on_rank0
+
+
+def _copy_tensors_(destinations, sources):
+    has_dtensor = any(isinstance(tensor, DTensor) for tensor in destinations) or any(
+        isinstance(tensor, DTensor) for tensor in sources
+    )
+    if has_dtensor:
+        for destination, source in zip(destinations, sources, strict=True):
+            destination.copy_(source)
+        return
+    torch._foreach_copy_(destinations, sources)
 
 
 class BF16Optimizer:
@@ -87,7 +99,7 @@ class BF16Optimizer:
                 else:
                     mp.grad = None
             if grad_destinations:
-                torch._foreach_copy_(grad_destinations, grad_sources)
+                _copy_tensors_(grad_destinations, grad_sources)
 
         grad_norm = torch.nn.utils.clip_grad_norm_(self.fp32_params, self.max_grad_norm)
 
@@ -98,14 +110,17 @@ class BF16Optimizer:
         if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
             # A sharded rank may be the only one that observes a nonfinite
             # gradient. All training ranks must make the same update decision.
-            dist.all_reduce(found_inf, op=dist.ReduceOp.MAX)
+            collective_found_inf = (
+                found_inf.to_local() if isinstance(found_inf, DTensor) else found_inf
+            )
+            dist.all_reduce(collective_found_inf, op=dist.ReduceOp.MAX)
         self.optimizer.found_inf = found_inf
         self.optimizer.step()
 
         self.optimizer.zero_grad()
         self.scheduler.step()
         with torch.no_grad():
-            torch._foreach_copy_(self.model_params, self.fp32_params)
+            _copy_tensors_(self.model_params, self.fp32_params)
             for p in self.model_params:
                 p.grad = None
 
@@ -126,7 +141,7 @@ class BF16Optimizer:
     def sync_fp32_params_from_model(self):
         """Reinitialize fp32_params from model params. Call after loading model checkpoint."""
         with torch.no_grad():
-            torch._foreach_copy_(self.fp32_params, self.model_params)
+            _copy_tensors_(self.fp32_params, self.model_params)
 
     def state_dict(self):
         return self.optimizer.state_dict()

--- a/torchspec/training/trainer.py
+++ b/torchspec/training/trainer.py
@@ -22,6 +22,7 @@ import abc
 import concurrent.futures
 import dataclasses
 import itertools
+import json
 import logging
 import os
 import time
@@ -44,7 +45,7 @@ from torchspec.training.data_fetcher import MooncakeDataFetcher, PrefetchedDataF
 from torchspec.training.fsdp import init_empty_weights
 from torchspec.training.optimizer import BF16Optimizer
 from torchspec.transfer.mooncake.eagle_store import EagleMooncakeStore
-from torchspec.utils.distributed import get_usp_device_mesh, get_usp_grad_sync_mesh
+from torchspec.utils.distributed import get_gloo_group, get_usp_device_mesh, get_usp_grad_sync_mesh
 from torchspec.utils.logging import logger
 from torchspec.utils.processing import get_assistant_token_ids
 from torchspec.utils.profiling import TrainProfiler
@@ -506,6 +507,30 @@ class Trainer(abc.ABC):
             return
         checkpoint.save(self, step=step)
 
+    def _write_serving_artifacts(self, model, state_dict: dict, output_dir: str) -> None:
+        if hasattr(model, "config"):
+            config = (
+                model.config_for_serving() if hasattr(model, "config_for_serving") else model.config
+            )
+            if isinstance(config, dict):
+                with open(os.path.join(output_dir, "config.json"), "w") as config_file:
+                    json.dump(config, config_file, indent=2)
+            else:
+                config.save_pretrained(output_dir)
+        if hasattr(model, "state_dict_for_serving"):
+            state_dict = model.state_dict_for_serving(state_dict)
+        torch.save(state_dict, os.path.join(output_dir, "pytorch_model.bin"))
+
+    def _synchronize_serving_error(self, error: Exception | None) -> str | None:
+        if not dist.is_initialized():
+            return None if error is None else f"{type(error).__name__}: {error}"
+
+        group = get_gloo_group()
+        errors = [None] * dist.get_world_size(group)
+        local_error = None if error is None else f"{type(error).__name__}: {error}"
+        dist.all_gather_object(errors, local_error, group=group)
+        return next((message for message in errors if message is not None), None)
+
     def save_draft_model_for_serving(self, output_dir: str) -> None:
         """Save draft model in HuggingFace format for serving update."""
         os.makedirs(output_dir, exist_ok=True)
@@ -513,7 +538,11 @@ class Trainer(abc.ABC):
         model = self.draft_model
         if hasattr(model, "module"):
             model = model.module
+        custom_schema = hasattr(model, "config_for_serving") or hasattr(
+            model, "state_dict_for_serving"
+        )
 
+        save_error = None
         try:
             state_dict = get_model_state_dict(
                 self.draft_model,
@@ -522,9 +551,12 @@ class Trainer(abc.ABC):
 
             if self.dp_rank == 0:
                 if hasattr(model, "save_pretrained"):
-                    if hasattr(model, "config"):
-                        model.config.save_pretrained(output_dir)
-                    torch.save(state_dict, os.path.join(output_dir, "pytorch_model.bin"))
+                    if custom_schema:
+                        self._write_serving_artifacts(model, state_dict, output_dir)
+                    else:
+                        if hasattr(model, "config"):
+                            model.config.save_pretrained(output_dir)
+                        torch.save(state_dict, os.path.join(output_dir, "pytorch_model.bin"))
                     logger.info(f"[Rank {self.dp_rank}] Saved draft model to {output_dir}")
                 else:
                     torch.save(state_dict, os.path.join(output_dir, "pytorch_model.bin"))
@@ -532,9 +564,50 @@ class Trainer(abc.ABC):
                         f"[Rank {self.dp_rank}] Saved draft model state dict to {output_dir}"
                     )
 
-        except Exception as e:
+        except Exception as error:
+            save_error = error
+
+        if custom_schema:
+            synchronized_error = self._synchronize_serving_error(save_error)
+            if synchronized_error is None:
+                return
+
+            strategy = getattr(getattr(self, "args", None), "fsdp_strategy", "REPLICATE")
+            if strategy.upper() == "FULL_SHARD":
+                if save_error is not None:
+                    raise save_error
+                raise RuntimeError(
+                    f"Failed to save a full serving state dict on another rank: "
+                    f"{synchronized_error}"
+                )
+
             logger.warning(
-                f"[Rank {self.dp_rank}] Failed to save with FSDP2 state dict, trying fallback: {e}"
+                f"[Rank {self.dp_rank}] Failed to save with FSDP2 state dict, trying fallback: "
+                f"{synchronized_error}"
+            )
+            fallback_error = None
+            try:
+                if self.dp_rank == 0:
+                    self._write_serving_artifacts(model, model.state_dict(), output_dir)
+                    logger.info(
+                        f"[Rank {self.dp_rank}] Saved draft model using save_pretrained to {output_dir}"
+                    )
+            except Exception as error:
+                fallback_error = error
+
+            synchronized_error = self._synchronize_serving_error(fallback_error)
+            if synchronized_error is not None:
+                if fallback_error is not None:
+                    raise fallback_error
+                raise RuntimeError(
+                    f"Failed to save serving artifacts on another rank: {synchronized_error}"
+                )
+            return
+
+        if save_error is not None:
+            logger.warning(
+                f"[Rank {self.dp_rank}] Failed to save with FSDP2 state dict, trying fallback: "
+                f"{save_error}"
             )
             if self.dp_rank == 0:
                 if hasattr(model, "save_pretrained"):

--- a/torchspec/training/trainer_actor.py
+++ b/torchspec/training/trainer_actor.py
@@ -26,11 +26,29 @@ import torch.distributed as dist
 
 from torchspec import AutoDraftModelConfig
 from torchspec.models.draft.dflash import DFlashConfig
+from torchspec.models.draft.dflash2 import DFlash2Config
 from torchspec.models.draft.dspark import DSparkConfig
 from torchspec.ray.ray_actor import RayActor
-from torchspec.training.eagle3_trainer import Eagle3Trainer
 from torchspec.utils.distributed import init_gloo_group, init_usp_groups
 from torchspec.utils.logging import setup_file_logging
+
+
+def _trainer_class_for_config(draft_model_config):
+    if isinstance(draft_model_config, DFlash2Config):
+        from torchspec.training.dflash2_trainer import DFlash2Trainer
+
+        return DFlash2Trainer
+    if isinstance(draft_model_config, DSparkConfig):
+        from torchspec.training.dspark_trainer import DSparkTrainer
+
+        return DSparkTrainer
+    if isinstance(draft_model_config, DFlashConfig):
+        from torchspec.training.dflash_trainer import DFlashTrainer
+
+        return DFlashTrainer
+    from torchspec.training.eagle3_trainer import Eagle3Trainer
+
+    return Eagle3Trainer
 
 
 class TrainerActor(RayActor):
@@ -76,21 +94,8 @@ class TrainerActor(RayActor):
         if draft_model_config is None and getattr(args, "draft_model_config", None):
             draft_model_config = AutoDraftModelConfig.from_file(args.draft_model_config)
 
-        # Config-based trainer dispatch.
-        # DSparkConfig subclasses DFlashConfig, so it must be checked first.
-        # - DSparkConfig → DSparkTrainer
-        # - DFlashConfig → DFlashTrainer
-        # - else Eagle3.
-        if isinstance(draft_model_config, DSparkConfig):
-            from torchspec.training.dspark_trainer import DSparkTrainer
-
-            self._trainer = DSparkTrainer(args)
-        elif isinstance(draft_model_config, DFlashConfig):
-            from torchspec.training.dflash_trainer import DFlashTrainer
-
-            self._trainer = DFlashTrainer(args)
-        else:
-            self._trainer = Eagle3Trainer(args)
+        trainer_class = _trainer_class_for_config(draft_model_config)
+        self._trainer = trainer_class(args)
 
         target_model_path = getattr(args, "target_model_path", None)
 


### PR DESCRIPTION
## Summary

- Add DFlash2 configuration, grouped dynamic causal convolution, candidate selection, and a thin wrapper around the shared DFlash training path.
- Export the public `DFlash2DraftModel` configuration and checkpoint schema used by SGLang and vLLM.
- Add fail-fast checks for unsupported configuration values that would change training-to-serving behavior.
- Add the Qwen3-8B recipe and focused tests for configuration, masking, loss, gradients, selector behavior, distributed export, and artifact schema.

## Public inference contract

TorchSpec follows the public DFlash2 architecture and serving behavior described by the [Inco overview](https://inco.ai/blog/dflash2/), [`z-lab/dflash`](https://github.com/z-lab/dflash/blob/07ebd93db9f472af339b644bb70221ad8428328a/dflash/model.py#L478-L547), [SGLang PR #35371](https://github.com/sgl-project/sglang/pull/35371), and [vLLM PR #52816](https://github.com/vllm-project/vllm/pull/52816):

- Apply grouped dynamic causal convolution around attention and the multilayer perceptron.
- Select the strict unary top-K candidates at each position.
- Apply the output multiplier and optional softcap.
- Add the predecessor-conditioned bilinear transition score.
- Use the verified anchor for the first predecessor, followed by the selected candidate from the previous position.
- Export the public configuration and checkpoint parameter names.

## Training objective boundary

The public sources describe the selector architecture and inference computation. They do not publish selector targets, a loss, negative construction, initialization, or a training schedule.

TorchSpec therefore defines a teacher-forced cross-entropy objective. Training uses the gold predecessor and inserts the gold successor when it is outside the unary top-K candidates. This insertion is training-only. Serving retains the strict public top-K set.

This pull request does not claim parity with an unpublished upstream training recipe.

## Validation

- Focused tests compare the grouped convolution and selector behavior with the public implementation and cover configuration, masks, positions, loss, gradients, distributed export, and checkpoint schema.
- Repository pre-commit checks pass.
- [Lint](https://github.com/lightseekorg/TorchSpec/actions/runs/32280874846) and the [CPU-safe test suite](https://github.com/lightseekorg/TorchSpec/actions/runs/32280909638) pass at the current pull-request head. The CPU-safe suite reports 580 passed and 44 skipped.
- The Qwen3-8B recipe was also exercised through training, export, and SGLang serving in a private test environment. Those artifacts are not linked here and do not replace the public repository checks.

## Limitations

- For an artifact with `block_size=B`, configure vLLM with `num_speculative_tokens=B-1`.
- The public sources do not disclose the upstream selector-training recipe or a production acceptance target. The included recipe and private integration exercise are not evidence of generalization or production throughput.
- The current configuration path rejects mixed full/sliding attention layouts and non-default RoPE scaling instead of exporting a model with different behavior.
- SGLang compatibility was exercised against its public DFlash2 implementation. The vLLM integration was source-reviewed but was not runtime-validated for this change.

## Related work

- DFlash: #64
- DSpark: #129
- Shared DFlash and DSpark training path: #134
