### PR TITLE
ci: wire GPU checks to patched vLLM nightly image

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Optional Docker image tag. Defaults to nightly-<short SHA>-vllm-v0.22.1.
+        description: Optional Docker image tag. Defaults to nightly-<short SHA>-vllm-pp.
         required: false
         type: string
 
@@ -17,7 +17,7 @@ permissions:
 
 env:
   IMAGE: lightseekorg/torchspec
-  VLLM_VERSION: v0.22.1
+  VLLM_BASE_TAG: nightly-e9d1398d9edfd90fcc1cf783805240e3effec013
 
 jobs:
   build:
@@ -63,15 +63,17 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/vllm/v0.22.1/Dockerfile
+          file: docker/vllm/nightly-e9d1398d9edfd90fcc1cf783805240e3effec013/Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           no-cache: true
           provenance: false
+          build-args: |
+            TORCHSPEC_SOURCE_REV=${{ github.sha }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=nightly-${{ github.sha }}-vllm-${{ env.VLLM_VERSION }}
+            org.opencontainers.image.version=nightly-${{ github.sha }}-vllm-pp
 
       - name: Export digest
         env:
@@ -115,8 +117,8 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          immutable_tag="${INPUT_TAG:-nightly-${GITHUB_SHA::7}-vllm-${VLLM_VERSION}}"
-          moving_tag="nightly-vllm-${VLLM_VERSION}"
+          immutable_tag="${INPUT_TAG:-nightly-${GITHUB_SHA::7}-vllm-pp}"
+          moving_tag="nightly-vllm-pp"
           for tag in "$immutable_tag" "$moving_tag"; do
             if [[ ! "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
               echo "::error::Invalid image tag: ${tag}" >&2
@@ -154,5 +156,5 @@ jobs:
             echo "- Digest: \`${digest}\`"
             echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
             echo "- TorchSpec commit: \`${GITHUB_SHA}\`"
-            echo "- vLLM base: \`${VLLM_VERSION}\`"
+            echo "- vLLM base: \`${VLLM_BASE_TAG}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gpu-integration.yml
+++ b/.github/workflows/gpu-integration.yml
@@ -114,6 +114,7 @@ jobs:
       TORCHSPEC_CI_MODEL_REVISION: ${{ vars.TORCHSPEC_CI_MODEL_REVISION || '1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0' }}
       TORCHSPEC_CI_SOURCE_SHA: ${{ needs.authorize.outputs.merge_sha }}
       TORCHSPEC_SLURM_ROOT: ${{ secrets.TORCHSPEC_SLURM_ROOT }}
+      # ARM64 .sqsh built from lightseekorg/torchspec:nightly-vllm-pp.
       TORCHSPEC_CI_IMAGE: ${{ secrets.TORCHSPEC_CI_IMAGE }}
       TORCHSPEC_CI_MODEL_CACHE_HOST: ${{ secrets.TORCHSPEC_CI_MODEL_CACHE_HOST }}
     steps:

--- a/.github/workflows/gpu-nightly.yml
+++ b/.github/workflows/gpu-nightly.yml
@@ -68,6 +68,7 @@ jobs:
       TORCHSPEC_CI_MODEL_REVISION: 1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0
       TORCHSPEC_CI_SOURCE_SHA: ${{ github.sha }}
       TORCHSPEC_SLURM_ROOT: ${{ secrets.TORCHSPEC_SLURM_ROOT }}
+      # ARM64 .sqsh built from lightseekorg/torchspec:nightly-vllm-pp.
       TORCHSPEC_CI_IMAGE: ${{ secrets.TORCHSPEC_CI_IMAGE }}
       TORCHSPEC_CI_MODEL_CACHE_HOST: ${{ secrets.TORCHSPEC_CI_MODEL_CACHE_HOST }}
     steps:

--- a/tools/ci/dispatch_slurm.sh
+++ b/tools/ci/dispatch_slurm.sh
@@ -24,6 +24,8 @@ image="${TORCHSPEC_CI_IMAGE}"
 model_cache_host="${TORCHSPEC_CI_MODEL_CACHE_HOST}"
 model="${TORCHSPEC_CI_MODEL:-Qwen/Qwen3.8-27B}"
 model_revision="${TORCHSPEC_CI_MODEL_REVISION:-1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0}"
+expected_vllm_commit="${TORCHSPEC_CI_EXPECTED_VLLM_COMMIT:-e9d1398d9edfd90fcc1cf783805240e3effec013}"
+expected_vllm_image_tag="${TORCHSPEC_CI_EXPECTED_VLLM_IMAGE_TAG:-vllm/vllm-openai:nightly-e9d1398d9edfd90fcc1cf783805240e3effec013}"
 
 case "${run_key}" in
   *[!0-9-]*) echo "Unsafe run key: ${run_key}" >&2; exit 2 ;;
@@ -58,7 +60,7 @@ fi
 mkdir -p "${repo_dir}" "${artifact_dir}" "${tmp_dir}"
 rsync -a --exclude=.git -- "${source_dir}/" "${repo_dir}/"
 
-export_spec="TORCHSPEC_CI_IMAGE=${image},TORCHSPEC_CI_REPO_DIR=${repo_dir},TORCHSPEC_CI_ARTIFACT_DIR=${artifact_dir},TORCHSPEC_CI_TMP_DIR=${tmp_dir},TORCHSPEC_CI_MODEL_CACHE_HOST=${model_cache_host},TORCHSPEC_CI_MODEL=${model},TORCHSPEC_CI_MODEL_REVISION=${model_revision}"
+export_spec="TORCHSPEC_CI_IMAGE=${image},TORCHSPEC_CI_REPO_DIR=${repo_dir},TORCHSPEC_CI_ARTIFACT_DIR=${artifact_dir},TORCHSPEC_CI_TMP_DIR=${tmp_dir},TORCHSPEC_CI_MODEL_CACHE_HOST=${model_cache_host},TORCHSPEC_CI_MODEL=${model},TORCHSPEC_CI_MODEL_REVISION=${model_revision},TORCHSPEC_CI_EXPECTED_VLLM_COMMIT=${expected_vllm_commit},TORCHSPEC_CI_EXPECTED_VLLM_IMAGE_TAG=${expected_vllm_image_tag}"
 submitted="$(sbatch \
   --parsable \
   --output="${run_root}/slurm-%j.log" \
@@ -103,6 +105,8 @@ sacct -j "${job_id}" -X --format=State,ExitCode,Elapsed,AllocTRES -P \
   echo "- Final state: \`${final_state}\`"
   echo "- Source SHA: \`${TORCHSPEC_CI_SOURCE_SHA:-${GITHUB_SHA:-unknown}}\`"
   echo "- Model revision: \`${model_revision}\`"
+  echo "- Expected vLLM commit: \`${expected_vllm_commit}\`"
+  echo "- Expected vLLM image: \`${expected_vllm_image_tag}\`"
 } | tee "${report_dir}/summary.md"
 
 if [[ "${final_state}" != COMPLETED ]]; then

--- a/tools/ci/gpu_2gpu.sbatch
+++ b/tools/ci/gpu_2gpu.sbatch
@@ -13,6 +13,8 @@ set -euo pipefail
 : "${TORCHSPEC_CI_TMP_DIR:?TORCHSPEC_CI_TMP_DIR is required}"
 : "${TORCHSPEC_CI_MODEL_CACHE_HOST:?TORCHSPEC_CI_MODEL_CACHE_HOST is required}"
 : "${TORCHSPEC_CI_MODEL_REVISION:?TORCHSPEC_CI_MODEL_REVISION is required}"
+: "${TORCHSPEC_CI_EXPECTED_VLLM_COMMIT:?TORCHSPEC_CI_EXPECTED_VLLM_COMMIT is required}"
+: "${TORCHSPEC_CI_EXPECTED_VLLM_IMAGE_TAG:?TORCHSPEC_CI_EXPECTED_VLLM_IMAGE_TAG is required}"
 
 container_mounts="${TORCHSPEC_CI_REPO_DIR}:/workspace:ro,${TORCHSPEC_CI_ARTIFACT_DIR}:/artifacts,${TORCHSPEC_CI_TMP_DIR}:/ci-tmp,${TORCHSPEC_CI_MODEL_CACHE_HOST}:/model-cache:ro"
 
@@ -32,7 +34,9 @@ srun --gpus=2 \
 
     nvidia-smi | tee "${TORCHSPEC_CI_ARTIFACT_DIR}/nvidia-smi.txt"
     python3 - <<'PY' | tee "${TORCHSPEC_CI_ARTIFACT_DIR}/runtime.txt"
+import os
 import platform
+from pathlib import Path
 
 import torch
 import vllm
@@ -43,6 +47,28 @@ print(f"torch={torch.__version__}")
 print(f"torch_cuda={torch.version.cuda}")
 print(f"vllm={vllm.__version__}")
 print(f"cuda_devices={torch.cuda.device_count()}")
+expected_commit = os.environ["TORCHSPEC_CI_EXPECTED_VLLM_COMMIT"]
+actual_commit = os.environ.get("VLLM_BUILD_COMMIT", "")
+print(f"vllm_build_commit={actual_commit}")
+if actual_commit != expected_commit:
+    raise SystemExit(
+        f"Unexpected vLLM build commit: expected {expected_commit}, got {actual_commit or '<missing>'}"
+    )
+expected_image = os.environ["TORCHSPEC_CI_EXPECTED_VLLM_IMAGE_TAG"]
+actual_image = os.environ.get("VLLM_IMAGE_TAG", "")
+print(f"vllm_image_tag={actual_image}")
+if actual_image != expected_image:
+    raise SystemExit(
+        f"Unexpected vLLM image: expected {expected_image}, got {actual_image or '<missing>'}"
+    )
+if os.environ.get("VLLM_USE_V2_MODEL_RUNNER") not in {"1", "true", "True"}:
+    raise SystemExit("Expected VLLM_USE_V2_MODEL_RUNNER=1")
+runtime_root = Path(vllm.__file__).resolve().parent.parent
+runner_source = (runtime_root / "vllm/v1/worker/gpu/model_runner.py").read_text()
+for marker in ("self.extract_hidden_states", "uses_extract_hidden_states"):
+    if marker not in runner_source:
+        raise SystemExit(f"Patched vLLM runtime marker is missing: {marker}")
+print("vllm_pp_extract_hidden_states_patch=present")
 if torch.cuda.device_count() != 2:
     raise SystemExit("Expected exactly two visible CUDA devices")
 PY


### PR DESCRIPTION
## Summary

The GPU CI dispatcher currently launches with `VLLM_USE_V2_MODEL_RUNNER=1`, but the nightly Docker publisher still builds the old v0.22.1 image. That image does not support the `extract_hidden_states` V2 path, causing the GPU smoke to fail during vLLM configuration before training starts.

This PR:

- switches the nightly publisher to the validated e9d1398d9edfd90fcc1cf783805240e3effec013 patched vLLM Dockerfile;
- publishes the immutable `nightly-<short-sha>-vllm-pp` and moving `nightly-vllm-pp` tags;
- records the TorchSpec source SHA in the image label;
- adds a trusted Slurm preflight that checks the vLLM build commit, base image tag, V2 runner setting, and extract-hidden-states patch markers;
- documents that `TORCHSPEC_CI_IMAGE` must point to an ARM64 `.sqsh` made from `nightly-vllm-pp`.

## Validation

- `git diff --check`
- `bash -n tools/ci/dispatch_slurm.sh tools/ci/gpu_2gpu.sbatch`
- embedded runtime Python syntax compilation
- YAML parsing for all three affected workflows

## Required post-merge infrastructure update

The repository secret `TORCHSPEC_CI_IMAGE` must be updated to the Inkwell ARM64 `.sqsh` imported from `lightseekorg/torchspec:nightly-vllm-pp`. The new preflight will report the expected and actual image metadata if the old `.sqsh` remains configured.
