### PR TITLE
feat: support frozen LM head training for EAGLE

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,6 +7,7 @@ model:
   draft_model_config: null
   embedding_key: model.embed_tokens.weight
   lm_head_key: lm_head.weight
+  freeze_lm_head: false
   target_model_backend: sglang
 
 dataset:

--- a/tests/test_freeze_lm_head.py
+++ b/tests/test_freeze_lm_head.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Frozen draft lm_head (``model.freeze_lm_head``)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from omegaconf import OmegaConf
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from torchspec.config.train_config import Config, config_to_flat_args
+from torchspec.models.draft.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from torchspec.training.checkpoint import resolve_resume_model_dir
+from torchspec.training.optimizer import BF16Optimizer
+
+_EAGLE3 = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "model_type": "llama",
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "vocab_size": 128,
+    "max_position_embeddings": 256,
+    "rms_norm_eps": 1e-6,
+    "rope_theta": 10000.0,
+    "pad_token_id": 0,
+    "tie_word_embeddings": False,
+}
+
+
+def _tmpdir(test: unittest.TestCase) -> Path:
+    directory = tempfile.TemporaryDirectory()
+    test.addCleanup(directory.cleanup)
+    return Path(directory.name)
+
+
+def _build(**overrides):
+    torch.manual_seed(0)
+    config = AutoDraftModelConfig.from_dict({**_EAGLE3, **overrides})
+    return AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32)
+
+
+def _publish_target(directory: Path, hidden_size: int = 64, vocab_size: int = 128) -> Path:
+    """A minimal single-file HF target checkpoint carrying just the keys we read."""
+    directory.mkdir(parents=True, exist_ok=True)
+    torch.manual_seed(7)
+    save_file(
+        {
+            "lm_head.weight": torch.randn(vocab_size, hidden_size),
+            "model.embed_tokens.weight": torch.randn(vocab_size, hidden_size),
+        },
+        str(directory / "model.safetensors"),
+    )
+    return directory
+
+
+class TestFreezeLmHead(unittest.TestCase):
+    def test_freeze_only_detaches_the_head(self):
+        model = _build()
+        model.freeze_lm_head()
+
+        self.assertFalse(model.lm_head.weight.requires_grad)
+        self.assertTrue(model.midlayer.self_attn.q_proj.weight.requires_grad)
+        self.assertTrue(model.fc.weight.requires_grad)
+        self.assertTrue(model.norm.weight.requires_grad)
+
+    def test_frozen_head_leaves_the_trainable_set(self):
+        """``BF16Optimizer`` keeps an fp32 master copy per trainable param, so the head's
+        optimizer state disappears with it -- the head is the largest draft tensor."""
+        model = _build()
+        model.freeze_embedding()
+
+        def trainable():
+            return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+        before = trainable()
+        model.freeze_lm_head()
+
+        self.assertEqual(before - trainable(), model.lm_head.weight.numel())
+
+    def test_load_lm_head_copies_the_target_rows(self):
+        target = _publish_target(_tmpdir(self) / "target")
+        model = _build()
+
+        model.load_lm_head(str(target))
+
+        with safe_open(str(target / "model.safetensors"), framework="pt") as f:
+            expected = f.get_tensor("lm_head.weight")
+        torch.testing.assert_close(model.lm_head.weight, expected)
+
+    def test_load_lm_head_rejects_a_shape_mismatch(self):
+        target = _publish_target(_tmpdir(self) / "target", hidden_size=32)
+        model = _build()
+
+        with self.assertRaisesRegex(ValueError, "does not match the draft lm_head"):
+            model.load_lm_head(str(target))
+
+    def test_load_lm_head_rejects_a_pruned_vocabulary(self):
+        """A pruned head's rows follow t2d, which is not populated until after model init."""
+        target = _publish_target(_tmpdir(self) / "target")
+        model = _build(draft_vocab_size=64)
+
+        with self.assertRaisesRegex(ValueError, "pruned draft vocabulary"):
+            model.load_lm_head(str(target))
+
+
+def _head_inputs(model, device="cpu"):
+    """Aux hidden states shaped for ``project_hidden_states``."""
+    width = model.fc.in_features
+    return torch.randn(2, 5, width, device=device)
+
+
+class TestFrozenHeadGradients(unittest.TestCase):
+    """The flag assertions above check declarations; these check autograd and the optimizer."""
+
+    def test_backward_leaves_no_gradient_on_the_head(self):
+        model = _build()
+        model.freeze_embedding()
+        model.freeze_lm_head()
+
+        logits = model.compute_logits(model.project_hidden_states(_head_inputs(model)))
+        logits.square().mean().backward()
+
+        self.assertIsNone(model.lm_head.weight.grad)
+        # The same graph must still reach the trainable parameters, or the test is vacuous.
+        self.assertIsNotNone(model.norm.weight.grad)
+        self.assertIsNotNone(model.fc.weight.grad)
+
+    def test_unfrozen_head_does_receive_a_gradient(self):
+        model = _build()
+
+        logits = model.compute_logits(model.project_hidden_states(_head_inputs(model)))
+        logits.square().mean().backward()
+
+        self.assertIsNotNone(model.lm_head.weight.grad)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available(), "BF16Optimizer builds fused AdamW, which requires CUDA"
+    )
+    def test_optimizer_steps_leave_the_frozen_head_bitwise_unchanged(self):
+        model = _build().cuda()
+        model.freeze_embedding()
+        model.freeze_lm_head()
+        optimizer = BF16Optimizer(model, lr=1e-2, total_steps=10)
+        head_before = model.lm_head.weight.detach().clone()
+        norm_before = model.norm.weight.detach().clone()
+
+        for _ in range(3):
+            logits = model.compute_logits(
+                model.project_hidden_states(_head_inputs(model, device="cuda"))
+            )
+            logits.square().mean().backward()
+            optimizer.step()
+
+        torch.testing.assert_close(model.lm_head.weight, head_before, rtol=0, atol=0)
+        self.assertFalse(torch.equal(model.norm.weight, norm_before))
+
+
+class TestResolveResumeModelDir(unittest.TestCase):
+    """Seeding keys off a resolved checkpoint, not off the load_path string.
+
+    ``load()`` skips a load_path that resolves to nothing, so treating the bare string as
+    "the head will arrive from a checkpoint" would freeze a randomly initialized head.
+    """
+
+    def _checkpoint(self, step: int = 10, with_model: bool = True) -> Path:
+        root = _tmpdir(self) / "run"
+        (root / f"iter_{step:07d}").mkdir(parents=True)
+        if with_model:
+            (root / f"iter_{step:07d}" / "model").mkdir()
+        (root / "latest_checkpointed_iteration.txt").write_text(f"{step}\n")
+        return root
+
+    def test_unset_path(self):
+        self.assertIsNone(resolve_resume_model_dir(SimpleNamespace(load_path=None)))
+
+    def test_nonexistent_path(self):
+        args = SimpleNamespace(load_path=str(_tmpdir(self) / "typo"), ckpt_step=None)
+
+        self.assertIsNone(resolve_resume_model_dir(args))
+
+    def test_directory_without_a_tracker(self):
+        root = _tmpdir(self) / "run"
+        root.mkdir()
+
+        self.assertIsNone(
+            resolve_resume_model_dir(SimpleNamespace(load_path=str(root), ckpt_step=None))
+        )
+
+    def test_tracker_pointing_at_a_step_with_no_model_dir(self):
+        root = self._checkpoint(with_model=False)
+
+        self.assertIsNone(
+            resolve_resume_model_dir(SimpleNamespace(load_path=str(root), ckpt_step=None))
+        )
+
+    def test_complete_checkpoint_resolves(self):
+        root = self._checkpoint(step=10)
+
+        resolved = resolve_resume_model_dir(SimpleNamespace(load_path=str(root), ckpt_step=None))
+
+        self.assertEqual(resolved, root / "iter_0000010" / "model")
+
+    def test_explicit_step_bypasses_the_tracker(self):
+        root = self._checkpoint(step=7)
+        (root / "latest_checkpointed_iteration.txt").unlink()
+
+        resolved = resolve_resume_model_dir(SimpleNamespace(load_path=str(root), ckpt_step=7))
+
+        self.assertEqual(resolved, root / "iter_0000007" / "model")
+
+
+class TestFreezeLmHeadConfig(unittest.TestCase):
+    def test_flag_defaults_off_and_reaches_the_flat_args(self):
+        config = OmegaConf.structured(Config)
+        self.assertFalse(config.model.freeze_lm_head)
+
+        config.model.freeze_lm_head = True
+        self.assertTrue(config_to_flat_args(config).freeze_lm_head)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optimizer_state_keys.py
+++ b/tests/test_optimizer_state_keys.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""fp32 master params are checkpointed by parameter name, not by position."""
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from torchspec.training.checkpoint import OptimizerState, _fp32_param_names
+
+
+class _Model(nn.Module):
+    """Ordered like a draft: a body, then the head that freezing removes."""
+
+    def __init__(self):
+        super().__init__()
+        self.body = nn.Linear(4, 4, bias=False)
+        self.lm_head = nn.Linear(4, 8, bias=False)
+        self.tail_norm = nn.Parameter(torch.ones(4))
+
+
+class _StubBF16Optimizer:
+    """Mimics the BF16Optimizer surface OptimizerState relies on.
+
+    The real one builds fused AdamW, which requires CUDA params, so it cannot be
+    constructed in a CPU-only test.
+    """
+
+    def __init__(self, model):
+        self.model = model
+        self.model_params = [p for p in model.parameters() if p.requires_grad]
+        self.fp32_params = [p.detach().clone().float() for p in self.model_params]
+        self._optim_state = {"step": 7}
+
+    def sync_fp32_params_from_model(self):  # marks this as a BF16Optimizer to OptimizerState
+        pass
+
+    def state_dict(self):
+        return self._optim_state
+
+    def load_state_dict(self, state_dict):
+        self._optim_state = state_dict
+
+
+class TestFp32ParamNames(unittest.TestCase):
+    def test_names_pair_with_fp32_params_positionally(self):
+        """Order is whatever ``model.parameters()`` walks; the pairing just has to agree."""
+        model = _Model()
+        opt = _StubBF16Optimizer(model)
+        by_name = dict(model.named_parameters())
+
+        names = _fp32_param_names(opt)
+
+        self.assertEqual(set(names), {"body.weight", "lm_head.weight", "tail_norm"})
+        self.assertEqual(len(names), len(opt.fp32_params))
+        for name, master in zip(names, opt.fp32_params, strict=True):
+            self.assertEqual(by_name[name].shape, master.shape)
+
+    def test_freezing_the_head_drops_only_its_name(self):
+        model = _Model()
+        model.lm_head.weight.requires_grad = False
+
+        names = _fp32_param_names(_StubBF16Optimizer(model))
+
+        self.assertEqual(set(names), {"body.weight", "tail_norm"})
+
+
+class TestOptimizerStateKeying(unittest.TestCase):
+    def test_state_dict_is_keyed_by_name(self):
+        state = OptimizerState(_Model(), _StubBF16Optimizer(_Model()))
+
+        keys = set(state.state_dict()["fp32_params"])
+
+        self.assertEqual(keys, {"body.weight", "lm_head.weight", "tail_norm"})
+
+    def test_round_trip_restores_each_master_copy(self):
+        model = _Model()
+        opt = _StubBF16Optimizer(model)
+        saved = OptimizerState(model, opt).state_dict()
+        saved = {
+            "optim": saved["optim"],
+            "fp32_params": {k: v.clone() for k, v in saved["fp32_params"].items()},
+        }
+
+        for master in opt.fp32_params:
+            master.zero_()
+        OptimizerState(model, opt).load_state_dict(saved)
+
+        for name, master in zip(_fp32_param_names(opt), opt.fp32_params):
+            torch.testing.assert_close(master, saved["fp32_params"][name])
+
+    def test_unfreezing_a_parameter_is_rejected_rather_than_misaligned(self):
+        """The two-stage case: stage 1 froze the head, stage 2 does not.
+
+        Under positional keys, every parameter after the head would silently receive
+        another parameter's saved tensor.
+        """
+        frozen_model = _Model()
+        frozen_model.lm_head.weight.requires_grad = False
+        frozen_opt = _StubBF16Optimizer(frozen_model)
+        saved = OptimizerState(frozen_model, frozen_opt).state_dict()
+        self.assertNotIn("lm_head.weight", saved["fp32_params"])
+
+        thawed_model = _Model()  # head trainable again
+        thawed_opt = _StubBF16Optimizer(thawed_model)
+
+        with self.assertRaisesRegex(ValueError, "lm_head.weight"):
+            OptimizerState(thawed_model, thawed_opt).load_state_dict(saved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -87,6 +87,7 @@ class ModelConfig:
     initial_draft_model_path: Optional[str] = None
     keep_initial_vocab_mapping: bool = False
     embedding_key: str = "model.embed_tokens.weight"
+    freeze_lm_head: bool = False
     lm_head_key: str = "lm_head.weight"
     norm_key: str = "model.norm.weight"
     target_model_backend: str = "sglang"

--- a/torchspec/models/draft/base.py
+++ b/torchspec/models/draft/base.py
@@ -221,6 +221,12 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
         """
         self.embed_tokens.weight.requires_grad = False
 
+    def freeze_lm_head(self) -> None:
+        """
+        Freeze the lm_head of the draft model so that it is not updated during training.
+        """
+        self.lm_head.weight.requires_grad = False
+
     @torch.no_grad()
     def load_embedding(
         self, model_path: str, embedding_key: str = "model.embed_tokens.weight"
@@ -232,46 +238,72 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
             model_path (str): Path to the target model. Can be either a Hugging Face
             repository ID or a local directory path containing the model files.
         """
-        if os.path.exists(model_path):
-            # model_path is a local directory
-            # check if there is file ending with index.json
-            glob_path = os.path.join(model_path, "*.index.json")
-            index_json_path = glob.glob(glob_path)
+        self.embed_tokens.weight.copy_(load_tensor_from_pretrained(model_path, embedding_key))
 
-            if len(index_json_path) == 0:
-                # No index.json found, look for single model file
-                safetensors_path = os.path.join(model_path, "model.safetensors")
-                if os.path.exists(safetensors_path):
-                    with safe_open(safetensors_path, framework="pt") as f:
-                        self.embed_tokens.weight.copy_(f.get_tensor(embedding_key))
-                    return
+    @torch.no_grad()
+    def load_lm_head(self, model_path: str, lm_head_key: str = "lm_head.weight") -> None:
+        """
+        Seed the draft lm_head from the target model's lm_head.
 
-                pytorch_model_path = os.path.join(model_path, "pytorch_model.bin")
-                if os.path.exists(pytorch_model_path):
-                    state_dict = torch.load(pytorch_model_path, map_location="cpu")
-                    self.embed_tokens.weight.copy_(state_dict[embedding_key])
-                    return
+        Only valid without vocabulary pruning. A pruned head's rows are ordered by ``t2d``, which
+        is not populated until after model construction (see ``set_vocab_buffers``), so the target
+        rows cannot be selected in draft order at this point.
 
-                raise FileNotFoundError(
-                    f"No index.json, model.safetensors or pytorch_model.bin found in {model_path}"
-                )
-            if len(index_json_path) > 1:
-                raise FileNotFoundError(f"Multiple index.json files found in {model_path}")
-            index_json_path = index_json_path[0]
+        Args:
+            model_path (str): Path to the target model. Can be either a Hugging Face
+            repository ID or a local directory path containing the model files.
+        """
+        if hasattr(self, "t2d"):
+            raise ValueError(
+                "load_lm_head does not support a pruned draft vocabulary: the head's rows are "
+                "ordered by a t2d mapping that is only computed after model init. Seed the head "
+                "from model.initial_draft_model_path or training.load_path instead."
+            )
+        weight = load_tensor_from_pretrained(model_path, lm_head_key)
+        if weight.shape != self.lm_head.weight.shape:
+            raise ValueError(
+                f"Target lm_head shape {tuple(weight.shape)} does not match the draft lm_head "
+                f"{tuple(self.lm_head.weight.shape)}. Seeding the draft head requires the draft "
+                "and target to share hidden size and vocabulary."
+            )
+        self.lm_head.weight.copy_(weight)
 
-            with open(index_json_path, "r") as f:
-                index_json = json.load(f)
-            ckpt_file = index_json["weight_map"][embedding_key]
 
-            if ckpt_file.endswith(".safetensors"):
-                with safe_open(os.path.join(model_path, ckpt_file), framework="pt") as f:
-                    emb_tokens = f.get_tensor(embedding_key)
-            else:
-                state_dict = torch.load(os.path.join(model_path, ckpt_file))
-                emb_tokens = state_dict[embedding_key]
-            self.embed_tokens.weight.copy_(emb_tokens)
-        else:
-            # this is the case where model_path is a huggingface repository
-            # we first need to locate its local cache
-            local_cache_path = snapshot_download(repo_id=model_path)
-            self.load_embedding(local_cache_path, embedding_key)
+def load_tensor_from_pretrained(model_path: str, key: str) -> torch.Tensor:
+    """Read a single tensor by key from an HF checkpoint directory or hub repository id."""
+    if not os.path.exists(model_path):
+        # model_path is a huggingface repository, so locate its local cache first
+        return load_tensor_from_pretrained(snapshot_download(repo_id=model_path), key)
+
+    # check if there is file ending with index.json
+    glob_path = os.path.join(model_path, "*.index.json")
+    index_json_path = glob.glob(glob_path)
+
+    if len(index_json_path) == 0:
+        # No index.json found, look for single model file
+        safetensors_path = os.path.join(model_path, "model.safetensors")
+        if os.path.exists(safetensors_path):
+            with safe_open(safetensors_path, framework="pt") as f:
+                return f.get_tensor(key)
+
+        pytorch_model_path = os.path.join(model_path, "pytorch_model.bin")
+        if os.path.exists(pytorch_model_path):
+            state_dict = torch.load(pytorch_model_path, map_location="cpu")
+            return state_dict[key]
+
+        raise FileNotFoundError(
+            f"No index.json, model.safetensors or pytorch_model.bin found in {model_path}"
+        )
+    if len(index_json_path) > 1:
+        raise FileNotFoundError(f"Multiple index.json files found in {model_path}")
+    index_json_path = index_json_path[0]
+
+    with open(index_json_path, "r") as f:
+        index_json = json.load(f)
+    ckpt_file = index_json["weight_map"][key]
+
+    if ckpt_file.endswith(".safetensors"):
+        with safe_open(os.path.join(model_path, ckpt_file), framework="pt") as f:
+            return f.get_tensor(key)
+    state_dict = torch.load(os.path.join(model_path, ckpt_file))
+    return state_dict[key]

--- a/torchspec/training/checkpoint.py
+++ b/torchspec/training/checkpoint.py
@@ -53,6 +53,11 @@ class ModelState(Stateful):
         )
 
 
+def _fp32_param_names(optimizer) -> list[str]:
+    """Names for a ``BF16Optimizer``'s fp32 master copies, in ``fp32_params`` order."""
+    return [name for name, param in optimizer.model.named_parameters() if param.requires_grad]
+
+
 class OptimizerState(Stateful):
     """Wrapper for optimizer + fp32 master params."""
 
@@ -63,9 +68,15 @@ class OptimizerState(Stateful):
 
     def state_dict(self):
         if self._is_bf16_optimizer:
+            names = _fp32_param_names(self.optimizer)
             return {
                 "optim": self.optimizer.state_dict(),
-                "fp32_params": {str(i): p.data for i, p in enumerate(self.optimizer.fp32_params)},
+                # Keyed by name: which parameters are trainable can differ between the run
+                # that saved and the run that loads.
+                "fp32_params": {
+                    name: param.data
+                    for name, param in zip(names, self.optimizer.fp32_params, strict=True)
+                },
             }
         _, optimizer_state_dict = get_state_dict(self.model, optimizers=[self.optimizer])
         return {"optim": optimizer_state_dict}
@@ -73,10 +84,21 @@ class OptimizerState(Stateful):
     def load_state_dict(self, state_dict):
         if self._is_bf16_optimizer:
             self.optimizer.load_state_dict(state_dict["optim"])
-            if "fp32_params" in state_dict:
+            saved = state_dict.get("fp32_params")
+            if saved:
+                names = _fp32_param_names(self.optimizer)
+                missing = [name for name in names if name not in saved]
+                if missing:
+                    raise ValueError(
+                        "Optimizer checkpoint does not cover every trainable parameter: "
+                        f"{missing[:5]}{'...' if len(missing) > 5 else ''}. The saved run trained "
+                        "a different parameter set (for example it froze the lm_head and this one "
+                        "does not). Use training.continual_training=true to start a fresh "
+                        "optimizer from those weights instead of resuming this one."
+                    )
                 with torch.no_grad():
-                    for i, mp in enumerate(self.optimizer.fp32_params):
-                        mp.data.copy_(state_dict["fp32_params"][str(i)])
+                    for name, master in zip(names, self.optimizer.fp32_params, strict=True):
+                        master.data.copy_(saved[name])
                 logger.info("Restored fp32 master params from checkpoint")
             return
         set_state_dict(
@@ -151,13 +173,14 @@ def load_initial_draft_weights(draft_model: torch.nn.Module, path: str) -> Path:
     return checkpoint_path
 
 
-def load(actor: Any) -> dict[str, Any] | None:
-    """Load checkpoint from disk.
+def resolve_resume_model_dir(args: Any) -> Path | None:
+    """Model directory ``training.load_path`` resolves to, or None if there is nothing to resume.
 
-    Loads model weights and optionally optimizer state from separate directories.
-    This allows loading weights without optimizer or deleting optimizer before loading.
+    Resolution is deliberately soft so a run can point at an output directory that has no
+    checkpoint yet, but callers that need weights to actually arrive must check the result
+    rather than the path string.
     """
-    load_root = getattr(actor.args, "load_path", None)
+    load_root = getattr(args, "load_path", None)
     if load_root is None:
         return None
 
@@ -166,23 +189,36 @@ def load(actor: Any) -> dict[str, Any] | None:
         logger.info(f"Checkpoint directory {root_path} not found; skipping load.")
         return None
 
-    target_step = getattr(actor.args, "ckpt_step", None)
+    target_step = getattr(args, "ckpt_step", None)
     if target_step is None:
         tracker_file = root_path / "latest_checkpointed_iteration.txt"
         if not tracker_file.exists():
             logger.info(f"No tracker file at {tracker_file}; skipping load.")
             return None
-        tracker_text = tracker_file.read_text().strip()
-        target_step = int(tracker_text)
+        target_step = int(tracker_file.read_text().strip())
 
-    checkpoint_dir = root_path / f"iter_{target_step:07d}"
-    model_dir = checkpoint_dir / "model"
-    optimizer_dir = checkpoint_dir / "optimizer"
-    lr_scheduler_dir = checkpoint_dir / "lr_scheduler"
-
+    model_dir = root_path / f"iter_{target_step:07d}" / "model"
     if not model_dir.exists():
         logger.info(f"Model checkpoint {model_dir} not found; skipping load.")
         return None
+    return model_dir
+
+
+def load(actor: Any) -> dict[str, Any] | None:
+    """Load checkpoint from disk.
+
+    Model weights and optimizer state live in separate directories. A resume requires both:
+    restoring weights without the matching optimizer state would leave the fp32 masters stale.
+    Use training.continual_training=true to start from the weights alone.
+    """
+    model_dir = resolve_resume_model_dir(actor.args)
+    if model_dir is None:
+        return None
+
+    checkpoint_dir = model_dir.parent
+    target_step = int(checkpoint_dir.name.removeprefix("iter_"))
+    optimizer_dir = checkpoint_dir / "optimizer"
+    lr_scheduler_dir = checkpoint_dir / "lr_scheduler"
 
     # Load model weights (always)
     model_state = ModelState(actor.model)
@@ -206,9 +242,21 @@ def load(actor: Any) -> dict[str, Any] | None:
             dcp.load(state_dict=optim_state_dict, checkpoint_id=str(optimizer_dir))
             logger.info(f"Loaded optimizer from {optimizer_dir}")
         except Exception as e:
-            logger.warning(f"Failed to load optimizer from {optimizer_dir}: {e}")
+            # The model is already restored but the fp32 masters still hold their pre-load
+            # values, and the first step would copy those back over the loaded weights.
+            raise RuntimeError(
+                f"Failed to load optimizer from {optimizer_dir}: {e}. The model weights were "
+                "restored, so continuing would let stale fp32 master params overwrite them on "
+                "the first optimizer step. Set training.continual_training=true to start a "
+                "fresh optimizer from these weights."
+            ) from e
     elif load_optimizer:
-        logger.info(f"Optimizer checkpoint not found at {optimizer_dir}, skipping optimizer load.")
+        raise RuntimeError(
+            f"No optimizer checkpoint at {optimizer_dir}. Resuming without it would leave the "
+            "fp32 master params holding their pre-load values, which the first optimizer step "
+            "would copy over the restored weights. Set training.continual_training=true to "
+            "start a fresh optimizer from these weights."
+        )
 
     # Load LR scheduler state (optional)
     load_lr_scheduler = (

--- a/torchspec/training/eagle3_trainer.py
+++ b/torchspec/training/eagle3_trainer.py
@@ -89,8 +89,15 @@ class Eagle3Trainer(Trainer):
                 torch_dtype=torch.bfloat16,
             )
 
+        initial_draft_model_path = getattr(self.args, "initial_draft_model_path", None)
+        freeze_lm_head = getattr(self.args, "freeze_lm_head", False)
+        # A head loaded from a checkpoint is frozen as-is; only a fresh one is seeded. The
+        # resume path is resolved rather than merely present: load() skips a load_path that
+        # resolves to nothing, which would otherwise freeze a randomly initialized head.
+        seed_lm_head_from_target = freeze_lm_head and not (
+            initial_draft_model_path or checkpoint.resolve_resume_model_dir(self.args)
+        )
         if dist.get_rank() == 0:
-            initial_draft_model_path = getattr(self.args, "initial_draft_model_path", None)
             if initial_draft_model_path:
                 loaded_from = checkpoint.load_initial_draft_weights(
                     draft_model, initial_draft_model_path
@@ -103,7 +110,18 @@ class Eagle3Trainer(Trainer):
                 embedding_key=getattr(self.args, "embedding_key", "model.embed_tokens"),
             )
 
+            if seed_lm_head_from_target:
+                draft_model.load_lm_head(
+                    target_model_path,
+                    lm_head_key=getattr(self.args, "lm_head_key", "lm_head.weight"),
+                )
+                logger.info(f"[Rank 0] Seeded draft lm_head from {target_model_path}")
+
         draft_model.freeze_embedding()
+        frozen_parts = ["embedding"]
+        if freeze_lm_head:
+            draft_model.freeze_lm_head()
+            frozen_parts.append("lm_head")
 
         dist.barrier(group=get_gloo_group())
 
@@ -111,7 +129,7 @@ class Eagle3Trainer(Trainer):
         trainable_count = sum(p.numel() for p in draft_model.parameters() if p.requires_grad)
         logger.info(
             f"[Rank {self.dp_rank}] Draft model: {trainable_count:,} trainable, "
-            f"{frozen_count:,} frozen (embedding) parameters"
+            f"{frozen_count:,} frozen ({', '.join(frozen_parts)}) parameters"
         )
 
         eagle3_model = Eagle3Model(


### PR DESCRIPTION
Add `model.freeze_lm_head` (default false). When set, the draft `lm_head` is seeded from the target's lm_head and frozen, leaving only the backbone trainable. Code rejects a pruned draft vocabulary, whose rows follow a t2d mapping that is not computed until after model init.

Checkpoint fp32 master params by parameter name instead of position. Which parameters are trainable can differ between the run that saved and the run that loads, and positional keys would silently pair a saved tensor with a different parameter. I.e. starting to train `lm_head` after a frozen warm run.

<img width="783" height="583" alt="image" src="https://github.com/user-attachments/assets/d67c3da1-305a-44e3-ad8d-f45adc156335" />

## Runtime: frozen vs unfrozen `lm_head`

**Qwen3-8B, 9,507 steps (1 epoch, 20K PerfectBlend rows) — job 2847, 4×GB300**

| Arm               | `freeze_lm_head` | Trainable params | Training loop | Steps/s | Δ vs baseline             |
| ----------------- | ---------------- | ---------------- | ------------- | ------- | ------------------------- |
| `baseline_lr1e-4` | false            | 890,781,696      | **12:52**     | 12.31   | —                         |
| `frozen_lr1e-4`   | true             | 268,451,840      | **10:31**     | 15.05   | **−18.3%** (1.22× faster) |
| `frozen_lr3e-4`   | true             | 268,451,840      | **10:28**     | 15.12   | **−18.6%** (1.23× faster) |

**Qwen3.8-27B, 1,001 steps — job 2798, 2×GB300**

| Arm      | `freeze_lm_head` | Training loop | Steps/s | Δ vs baseline             |
| -------- | ---------------- | ------------- | ------- | ------------------------- |
| baseline | false            | **03:38**     | 4.58    | —                         |
| frozen   | true             | **02:35**     | 6.44    | **−28.9%** (1.41× faster) |
