### PR TITLE
feat: support LoRA LM Head

### DIFF
--- a/tests/test_eagle3_loss.py
+++ b/tests/test_eagle3_loss.py
@@ -187,7 +187,7 @@ class TestCompiledForwardKLLoss(unittest.TestCase):
         target_p = F.softmax(raw_logits + torch.randn_like(raw_logits) * 0.5, dim=-1)
 
         loss_sum, correct, count = compiled_forward_kl_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, norm_eps
         )
         loss = loss_sum / count
         acc = correct / count
@@ -218,7 +218,7 @@ class TestCompiledForwardKLLoss(unittest.TestCase):
         expected_entropy = -(target_p * target_p.log()).sum(-1).mean()
 
         loss_sum, correct, count = compiled_forward_kl_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, norm_eps
         )
         loss = loss_sum / count
         acc = correct / count
@@ -235,7 +235,7 @@ class TestCompiledForwardKLLoss(unittest.TestCase):
         valid_idx = torch.arange(N)
 
         loss_sum, correct, count = compiled_forward_kl_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, 1e-6
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, 1e-6
         )
         loss = loss_sum / count
         acc = correct / count
@@ -262,7 +262,7 @@ class TestCompiledLkAlphaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, correct, count, alpha_sum = compiled_lk_alpha_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, norm_eps, coverage
         )
         loss, acc, alpha = loss_sum / count, correct / count, alpha_sum / count
         ref_loss, ref_acc, ref_alpha = _reference_lk_alpha_loss(
@@ -288,10 +288,17 @@ class TestCompiledLkAlphaLoss(unittest.TestCase):
         coverage = torch.rand(N) * 0.5 + 0.3  # in [0.3, 0.8): meaningful vocab pruning
 
         _, _, _, alpha_sum_no_coverage = compiled_lk_alpha_loss(
-            hs, target_p_tilde, valid_idx, norm_weight, lm_head_weight, norm_eps, torch.ones(N)
+            hs,
+            target_p_tilde,
+            valid_idx,
+            norm_weight,
+            lm_head_weight,
+            None,
+            norm_eps,
+            torch.ones(N),
         )
         _, _, _, alpha_sum_with_coverage = compiled_lk_alpha_loss(
-            hs, target_p_tilde, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage
+            hs, target_p_tilde, valid_idx, norm_weight, lm_head_weight, None, norm_eps, coverage
         )
         # Rescaling by coverage < 1 can only shrink (never inflate) alpha,
         # since it shrinks every component of the min(p, q) sum.
@@ -300,7 +307,7 @@ class TestCompiledLkAlphaLoss(unittest.TestCase):
             hs, target_p_tilde, norm_weight, lm_head_weight, norm_eps, coverage
         )
         loss_sum, _, count, alpha_sum = compiled_lk_alpha_loss(
-            hs, target_p_tilde, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage
+            hs, target_p_tilde, valid_idx, norm_weight, lm_head_weight, None, norm_eps, coverage
         )
         torch.testing.assert_close(loss_sum / count, ref_loss, atol=1e-4, rtol=1e-4)
         torch.testing.assert_close(alpha_sum / count, ref_alpha, atol=1e-4, rtol=1e-4)
@@ -323,7 +330,7 @@ class TestCompiledLkAlphaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, correct, count, alpha_sum = compiled_lk_alpha_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, norm_eps, coverage
         )
         loss, acc, alpha = loss_sum / count, correct / count, alpha_sum / count
         self.assertAlmostEqual(loss.item(), 0.0, places=3)
@@ -341,7 +348,7 @@ class TestCompiledLkAlphaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, correct, count, alpha_sum = compiled_lk_alpha_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, 1e-6, coverage
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, 1e-6, coverage
         )
         loss, alpha = loss_sum / count, alpha_sum / count
         self.assertTrue(torch.isfinite(loss))
@@ -367,7 +374,16 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, correct, count, alpha_sum = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage, None, eta
+            hs,
+            target_p,
+            valid_idx,
+            norm_weight,
+            lm_head_weight,
+            None,
+            norm_eps,
+            coverage,
+            None,
+            eta,
         )
         loss, acc, alpha = loss_sum / count, correct / count, alpha_sum / count
         ref_loss, ref_acc, ref_alpha = _reference_lk_lambda_loss(
@@ -390,10 +406,10 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_eta3, _, count3, _ = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, 1e-6, coverage, None, 3.0
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, 1e-6, coverage, None, 3.0
         )
         loss_eta10, _, count10, _ = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, 1e-6, coverage, None, 10.0
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, 1e-6, coverage, None, 10.0
         )
         self.assertFalse(torch.allclose(loss_eta3 / count3, loss_eta10 / count10))
 
@@ -418,6 +434,7 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage,
             None,
@@ -454,7 +471,16 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, _, _count, _alpha_sum = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage, None, eta
+            hs,
+            target_p,
+            valid_idx,
+            norm_weight,
+            lm_head_weight,
+            None,
+            norm_eps,
+            coverage,
+            None,
+            eta,
         )
 
         variance = hs.pow(2).mean(-1, keepdim=True)
@@ -494,7 +520,16 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_local, _, count, alpha_sum = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage, None, eta
+            hs,
+            target_p,
+            valid_idx,
+            norm_weight,
+            lm_head_weight,
+            None,
+            norm_eps,
+            coverage,
+            None,
+            eta,
         )
         local_mean_alpha = alpha_sum / count
 
@@ -508,6 +543,7 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage,
             external_mean_alpha,
@@ -545,7 +581,16 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, _correct, count, alpha_sum = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, norm_eps, coverage, None, 3.0
+            hs,
+            target_p,
+            valid_idx,
+            norm_weight,
+            lm_head_weight,
+            None,
+            norm_eps,
+            coverage,
+            None,
+            3.0,
         )
         loss, alpha = loss_sum / count, alpha_sum / count
         self.assertAlmostEqual(loss.item(), 0.0, places=3)
@@ -562,7 +607,7 @@ class TestCompiledLkLambdaLoss(unittest.TestCase):
         coverage = torch.ones(N)
 
         loss_sum, _correct, count, _alpha_sum = compiled_lk_lambda_loss(
-            hs, target_p, valid_idx, norm_weight, lm_head_weight, 1e-6, coverage, None, 3.0
+            hs, target_p, valid_idx, norm_weight, lm_head_weight, None, 1e-6, coverage, None, 3.0
         )
         loss = loss_sum / count
         self.assertTrue(torch.isfinite(loss))
@@ -623,6 +668,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
                 seq_length=seq_length,
                 norm_weight=norm_weight,
                 lm_head_weight=lm_head_weight,
+                lm_head_up=None,
                 norm_eps=norm_eps,
             )
         mock_reduce.assert_called_once()
@@ -642,6 +688,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage_flat,
             None,
@@ -660,6 +707,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage_flat,
             expected_mean_alpha,
@@ -684,6 +732,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
                 seq_length=mask.shape[1],
                 norm_weight=norm_weight,
                 lm_head_weight=lm_head_weight,
+                lm_head_up=None,
                 norm_eps=norm_eps,
             )
 
@@ -725,6 +774,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
                 seq_length=seq_length,
                 norm_weight=norm_weight,
                 lm_head_weight=lm_head_weight,
+                lm_head_up=None,
                 norm_eps=norm_eps,
             )
 
@@ -738,6 +788,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
                 valid_idx,
                 norm_weight,
                 lm_head_weight,
+                None,
                 target.lm_head_weight,
                 norm_eps,
                 None,
@@ -755,6 +806,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             target.lm_head_weight,
             norm_eps,
             expected_mean_alpha,
@@ -779,6 +831,7 @@ class TestUspLambdaAlphaReduction(unittest.TestCase):
                 seq_length=mask.shape[1],
                 norm_weight=norm_weight,
                 lm_head_weight=lm_head_weight,
+                lm_head_up=None,
                 norm_eps=norm_eps,
             )
         mock_reduce.assert_not_called()
@@ -1062,6 +1115,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
         )
         loss = loss_sum / count
@@ -1076,6 +1130,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             all_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
         )
         loss_ref = loss_sum_ref / count_ref
@@ -1099,6 +1154,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             target_lm_head_weight,
             norm_eps,
         )
@@ -1114,6 +1170,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             all_idx,
             norm_weight,
             lm_head_weight,
+            None,
             target_lm_head_weight,
             norm_eps,
         )
@@ -1138,6 +1195,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage_flat,
         )
@@ -1153,6 +1211,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             all_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage_valid,
         )
@@ -1180,6 +1239,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             valid_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage_flat,
             None,
@@ -1197,6 +1257,7 @@ class TestValidIdxSubsetting(unittest.TestCase):
             all_idx,
             norm_weight,
             lm_head_weight,
+            None,
             norm_eps,
             coverage_valid,
             None,

--- a/tests/test_low_rank_lm_head.py
+++ b/tests/test_low_rank_lm_head.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Factorized draft lm_head (``lm_head_rank``)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+from torchspec.models.draft.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from torchspec.models.draft.base import LowRankHead, build_lm_head
+from torchspec.models.ops.loss import _project
+
+H, V, DIVISOR = 64, 128, 8
+RANK = H // DIVISOR
+
+_EAGLE3 = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "model_type": "llama",
+    "hidden_size": H,
+    "intermediate_size": 128,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "vocab_size": V,
+    "max_position_embeddings": 256,
+    "rms_norm_eps": 1e-6,
+    "rope_theta": 10000.0,
+    "pad_token_id": 0,
+    "tie_word_embeddings": False,
+}
+
+
+def _build(**overrides):
+    torch.manual_seed(0)
+    config = AutoDraftModelConfig.from_dict({**_EAGLE3, **overrides})
+    return AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32)
+
+
+def _tmpdir(test: unittest.TestCase) -> Path:
+    directory = tempfile.TemporaryDirectory()
+    test.addCleanup(directory.cleanup)
+    return Path(directory.name)
+
+
+class TestLowRankHead(unittest.TestCase):
+    def test_shapes_and_parameter_count(self):
+        head = LowRankHead(H, V, DIVISOR)
+
+        self.assertEqual(tuple(head.down.weight.shape), (RANK, H))
+        self.assertEqual(tuple(head.up.weight.shape), (V, RANK))
+        self.assertEqual(sum(p.numel() for p in head.parameters()), RANK * (H + V))
+
+    def test_forward_matches_the_materialized_product(self):
+        head = LowRankHead(H, V, DIVISOR)
+        hidden = torch.randn(5, H)
+
+        dense = head.up.weight @ head.down.weight
+        torch.testing.assert_close(head(hidden), F.linear(hidden, dense), atol=1e-5, rtol=1e-5)
+
+    def test_divisor_must_shrink_the_head(self):
+        for bad in (0, 1, -1):
+            with self.assertRaisesRegex(ValueError, "at least 2"):
+                LowRankHead(H, V, bad)
+
+    def test_divisor_larger_than_hidden_size_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "leaves no rank"):
+            LowRankHead(H, V, H + 1)
+
+    def test_rank_is_hidden_size_over_divisor(self):
+        self.assertEqual(LowRankHead(H, V, 4).rank, H // 4)
+
+    def test_state_dict_uses_the_down_up_convention(self):
+        keys = set(LowRankHead(H, V, DIVISOR).state_dict())
+
+        self.assertEqual(keys, {"down.weight", "up.weight"})
+
+
+class TestBuildLmHead(unittest.TestCase):
+    def test_no_rank_gives_a_dense_linear(self):
+        config = AutoDraftModelConfig.from_dict(dict(_EAGLE3))
+
+        head = build_lm_head(config, H, V, V)
+
+        self.assertIsInstance(head, nn.Linear)
+
+    def test_rank_gives_a_factorized_head(self):
+        config = AutoDraftModelConfig.from_dict({**_EAGLE3, "lm_head_rank_divisor": DIVISOR})
+
+        head = build_lm_head(config, H, V, V)
+
+        self.assertIsInstance(head, LowRankHead)
+
+    def test_pruned_vocabulary_is_rejected(self):
+        config = AutoDraftModelConfig.from_dict({**_EAGLE3, "lm_head_rank_divisor": DIVISOR})
+
+        with self.assertRaisesRegex(ValueError, "pruned draft vocabulary"):
+            build_lm_head(config, H, 32, V)
+
+
+class TestProject(unittest.TestCase):
+    """The loss path takes the two factors rather than a materialized head."""
+
+    def test_dense_path_is_a_single_projection(self):
+        hidden, weight = torch.randn(5, H), torch.randn(V, H)
+
+        torch.testing.assert_close(_project(hidden, weight, None), F.linear(hidden, weight))
+
+    def test_factorized_path_matches_the_dense_equivalent(self):
+        hidden = torch.randn(5, H)
+        down, up = torch.randn(RANK, H), torch.randn(V, RANK)
+
+        torch.testing.assert_close(
+            _project(hidden, down, up), F.linear(hidden, up @ down), atol=1e-5, rtol=1e-5
+        )
+
+
+class TestModelIntegration(unittest.TestCase):
+    def test_draft_exposes_both_factors_to_the_loss(self):
+        model = _build(lm_head_rank_divisor=DIVISOR)
+
+        _, projection, _ = model.get_lm_head_params()
+        up = model.get_lm_head_up_weight()
+
+        self.assertTrue(model.is_lm_head_factorized)
+        self.assertEqual(tuple(projection.shape), (RANK, H))
+        self.assertEqual(tuple(up.shape), (V, RANK))
+
+    def test_dense_draft_reports_no_second_factor(self):
+        model = _build()
+
+        self.assertFalse(model.is_lm_head_factorized)
+        self.assertIsNone(model.get_lm_head_up_weight())
+
+    def test_freeze_covers_both_factors(self):
+        model = _build(lm_head_rank_divisor=DIVISOR)
+
+        model.freeze_lm_head()
+
+        self.assertFalse(model.lm_head.down.weight.requires_grad)
+        self.assertFalse(model.lm_head.up.weight.requires_grad)
+        self.assertTrue(model.midlayer.self_attn.q_proj.weight.requires_grad)
+
+    def test_factorized_head_shrinks_the_trainable_set(self):
+        dense = sum(p.numel() for p in _build().parameters() if p.requires_grad)
+        low_rank = sum(
+            p.numel() for p in _build(lm_head_rank_divisor=DIVISOR).parameters() if p.requires_grad
+        )
+
+        self.assertEqual(dense - low_rank, V * H - RANK * (H + V))
+
+
+class TestSeeding(unittest.TestCase):
+    def test_seeding_a_factorized_head_from_the_target_is_refused(self):
+        directory = _tmpdir(self) / "target"
+        directory.mkdir(parents=True, exist_ok=True)
+        save_file({"lm_head.weight": torch.randn(V, H)}, str(directory / "model.safetensors"))
+        model = _build(lm_head_rank_divisor=DIVISOR)
+
+        with self.assertRaisesRegex(ValueError, "factorized lm_head"):
+            model.load_lm_head(str(directory))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -308,6 +308,13 @@ def _save_with_vocab_pruning(
     tensors["t2d"] = t2d
     tensors["d2t"] = d2t
 
+    if "lm_head.up.weight" in tensors:
+        raise ValueError(
+            "Post-training vocabulary pruning is not supported for a factorized lm_head "
+            "(lm_head_rank). The head is stored as lm_head.down / lm_head.up, so trimming rows "
+            "would mean re-factorizing it. Train with a dense head to use --prune-vocab."
+        )
+
     lm_head_key = "lm_head.weight"
     if lm_head_key in tensors:
         current_size = tensors[lm_head_key].shape[0]

--- a/torchspec/models/draft/base.py
+++ b/torchspec/models/draft/base.py
@@ -27,6 +27,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Tuple
 
 import torch
+import torch.nn as nn
 from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from transformers.modeling_utils import PreTrainedModel
@@ -89,6 +90,43 @@ def prepare_decoder_attention_mask(
         )
 
     return combined_attention_mask
+
+
+class LowRankHead(nn.Module):
+    """Factorized output projection of rank ``hidden_size // divisor``.
+
+    ``down.weight`` is ``[rank, hidden]`` and ``up.weight`` is ``[vocab, rank]``; the dense
+    product is never materialized.
+    """
+
+    def __init__(self, hidden_size: int, vocab_size: int, divisor: int) -> None:
+        super().__init__()
+        if divisor < 2:
+            raise ValueError(f"lm_head_rank_divisor must be at least 2, got {divisor}")
+        rank = hidden_size // divisor
+        if rank < 1:
+            raise ValueError(
+                f"lm_head_rank_divisor={divisor} leaves no rank for hidden_size={hidden_size}"
+            )
+        self.rank = rank
+        self.down = nn.Linear(hidden_size, rank, bias=False)
+        self.up = nn.Linear(rank, vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.up(self.down(hidden_states))
+
+
+def build_lm_head(config, hidden_size: int, vocab_size: int, target_vocab_size: int) -> nn.Module:
+    """Dense head, or a ``LowRankHead`` when the config sets ``lm_head_rank_divisor``."""
+    divisor = getattr(config, "lm_head_rank_divisor", None)
+    if not divisor:
+        return nn.Linear(hidden_size, vocab_size, bias=False)
+    if vocab_size != target_vocab_size:
+        raise ValueError(
+            f"lm_head_rank_divisor is not supported with a pruned draft vocabulary "
+            f"(draft_vocab_size={vocab_size} < vocab_size={target_vocab_size})."
+        )
+    return LowRankHead(hidden_size, vocab_size, divisor)
 
 
 class Eagle3DraftModel(PreTrainedModel, ABC):
@@ -176,12 +214,22 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
         The backbone of the draft model.
         """
 
-    def get_lm_head_params(self) -> Tuple[torch.Tensor, torch.Tensor, float]:
-        """Return (norm_weight, lm_head_weight, norm_eps) for fused loss computation.
+    @property
+    def is_lm_head_factorized(self) -> bool:
+        return isinstance(self.lm_head, LowRankHead)
 
-        Override if your model uses a different normalization scheme.
+    def get_lm_head_params(self) -> Tuple[torch.Tensor, torch.Tensor, float]:
+        """Return (norm_weight, projection_weight, norm_eps) for fused loss computation.
+
+        For a factorized head the projection is the down weight; pair it with
+        ``get_lm_head_up_weight()``. Override for a different normalization scheme.
         """
-        return self.norm.weight, self.lm_head.weight, self.norm.variance_epsilon
+        weight = self.lm_head.down.weight if self.is_lm_head_factorized else self.lm_head.weight
+        return self.norm.weight, weight, self.norm.variance_epsilon
+
+    def get_lm_head_up_weight(self) -> Optional[torch.Tensor]:
+        """Second factor ``[vocab, rank]`` of a factorized head, or None when it is dense."""
+        return self.lm_head.up.weight if self.is_lm_head_factorized else None
 
     @property
     def has_vocab_pruning(self) -> bool:
@@ -225,7 +273,8 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
         """
         Freeze the lm_head of the draft model so that it is not updated during training.
         """
-        self.lm_head.weight.requires_grad = False
+        for param in self.lm_head.parameters():
+            param.requires_grad = False
 
     @torch.no_grad()
     def load_embedding(
@@ -258,6 +307,11 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
                 "load_lm_head does not support a pruned draft vocabulary: the head's rows are "
                 "ordered by a t2d mapping that is only computed after model init. Seed the head "
                 "from model.initial_draft_model_path or training.load_path instead."
+            )
+        if self.is_lm_head_factorized:
+            raise ValueError(
+                "load_lm_head does not support a factorized lm_head (lm_head_rank_divisor); "
+                "the target head is dense and has no factors to seed."
             )
         weight = load_tensor_from_pretrained(model_path, lm_head_key)
         if weight.shape != self.lm_head.weight.shape:

--- a/torchspec/models/draft/deepseek_eagle.py
+++ b/torchspec/models/draft/deepseek_eagle.py
@@ -30,7 +30,7 @@ import torch.nn.functional as F
 from torch.nn.attention.flex_attention import flex_attention
 from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
 
-from torchspec.models.draft.base import Eagle3DraftModel
+from torchspec.models.draft.base import Eagle3DraftModel, build_lm_head
 
 # TODO: Extract shared components into a common module to reduce duplication:
 # - LlamaMLP, LlamaRMSNorm, RoPE classes → torchspec/models/draft/modules.py
@@ -471,7 +471,9 @@ class Eagle3DeepseekV2ForCausalLM(Eagle3DraftModel):
 
         self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.norm_output = getattr(config, "norm_output", False)
-        self.lm_head = nn.Linear(config.hidden_size, self.vocab_size, bias=False)
+        self.lm_head = build_lm_head(
+            config, config.hidden_size, self.vocab_size, self.target_vocab_size
+        )
 
         if self.vocab_size != self.target_vocab_size:
             self.register_buffer("t2d", torch.ones(self.target_vocab_size, dtype=torch.bool))

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -32,7 +32,7 @@ from transformers.activations import ACT2FN
 from transformers.models.llama.configuration_llama import LlamaConfig
 
 from torchspec.config.utils import resolve_rope_theta
-from torchspec.models.draft.base import Eagle3DraftModel
+from torchspec.models.draft.base import Eagle3DraftModel, build_lm_head
 from torchspec.models.ops.flex_attention import (
     compile_friendly_flex_attention,
     eagle3_block_mask,
@@ -2467,7 +2467,9 @@ class LlamaForCausalLMEagle3(Eagle3DraftModel):
 
         self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.norm_output = getattr(config, "norm_output", False)
-        self.lm_head = nn.Linear(config.hidden_size, self.vocab_size, bias=False)
+        self.lm_head = build_lm_head(
+            config, config.hidden_size, self.vocab_size, self.target_vocab_size
+        )
 
         if self.vocab_size != self.target_vocab_size:
             self.register_buffer("t2d", torch.ones(self.target_vocab_size, dtype=torch.bool))

--- a/torchspec/models/eagle3.py
+++ b/torchspec/models/eagle3.py
@@ -152,6 +152,7 @@ class Eagle3Model(nn.Module):
         norm_weight: torch.Tensor,
         lm_head_weight: torch.Tensor,
         norm_eps: float,
+        lm_head_up: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Returns (loss_sum, correct_sum, count, alpha_sum).
 
@@ -182,7 +183,7 @@ class Eagle3Model(nn.Module):
         if isinstance(target, PrecomputedTarget):
             target_p_step = target.target_p_padded[:, idx : idx + seq_length, :]
             tp_flat = target_p_step.reshape(-1, target_p_step.shape[-1])
-            args = (hs_flat, tp_flat, valid_idx, norm_weight, lm_head_weight, norm_eps)
+            args = (hs_flat, tp_flat, valid_idx, norm_weight, lm_head_weight, lm_head_up, norm_eps)
             if self.loss_type == "lk_alpha":
                 fn = compiled_lk_alpha_loss
                 args = args + (self._coverage_flat(target, idx, seq_length, tp_flat),)
@@ -194,6 +195,7 @@ class Eagle3Model(nn.Module):
                     valid_idx,
                     norm_weight,
                     lm_head_weight,
+                    lm_head_up,
                     norm_eps,
                     coverage_flat,
                 )
@@ -220,6 +222,7 @@ class Eagle3Model(nn.Module):
                 valid_idx,
                 norm_weight,
                 lm_head_weight,
+                lm_head_up,
                 target.lm_head_weight,
                 norm_eps,
             )
@@ -271,6 +274,7 @@ class Eagle3Model(nn.Module):
         past_key_values_length = 0
 
         norm_weight, lm_head_weight, norm_eps = self.draft_model.get_lm_head_params()
+        lm_head_up = self.draft_model.get_lm_head_up_weight()
         hidden_states = self.draft_model.project_hidden_states(hidden_states)
 
         if past_key_values is not None:
@@ -387,6 +391,7 @@ class Eagle3Model(nn.Module):
                 norm_weight=norm_weight,
                 lm_head_weight=lm_head_weight,
                 norm_eps=norm_eps,
+                lm_head_up=lm_head_up,
             )
 
             # Model takes its own normed hidden states as input for the next step, so apply norm here if needed.

--- a/torchspec/models/ops/loss.py
+++ b/torchspec/models/ops/loss.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Optional
+
 import torch
 import torch.nn.functional as F
 
@@ -32,17 +34,30 @@ def _softmax_from_logits(logits: torch.Tensor) -> torch.Tensor:
     return torch.exp(logits_f32 - torch.logsumexp(logits_f32, dim=-1, keepdim=True))
 
 
+def _project(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    lm_head_up: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Draft logits. ``lm_head_up`` is None for a dense head, the up projection otherwise."""
+    logits = F.linear(hidden, lm_head_weight)
+    if lm_head_up is not None:
+        logits = F.linear(logits, lm_head_up)
+    return logits
+
+
 def _rmsnorm_logits(
     hs_flat: torch.Tensor,
     norm_weight: torch.Tensor,
     lm_head_weight: torch.Tensor,
+    lm_head_up: Optional[torch.Tensor],
     norm_eps: float,
 ) -> torch.Tensor:
     hs_f32 = hs_flat.float()
     variance = hs_f32.pow(2).mean(-1, keepdim=True)
     rstd = torch.rsqrt(variance + norm_eps)
     norm_hs = (hs_f32 * rstd).to(hs_flat.dtype) * norm_weight
-    return F.linear(norm_hs, lm_head_weight)
+    return _project(norm_hs, lm_head_weight, lm_head_up)
 
 
 @torch.compile(dynamic=None)
@@ -52,6 +67,7 @@ def compiled_sum_forward_kl_loss(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     norm_eps,
 ):
     hs = prenorm_hidden_states_flat.index_select(0, valid_idx)
@@ -62,7 +78,7 @@ def compiled_sum_forward_kl_loss(
     rstd = torch.rsqrt(variance + norm_eps)
     norm_hs = (hs_f32 * rstd).to(hs.dtype) * norm_weight
 
-    logits = F.linear(norm_hs, lm_head_weight)
+    logits = _project(norm_hs, lm_head_weight, lm_head_up)
     token_loss = _forward_kl_from_logits(logits, tp)
     correct = (logits.argmax(-1) == tp.argmax(-1)).float()
     count = torch.ones_like(token_loss, dtype=torch.float32).sum()
@@ -76,6 +92,7 @@ def compiled_forward_kl_loss(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     norm_eps,
 ):
     """torch.compile'd index_select + RMSNorm + lm_head + Forward KL loss.
@@ -100,7 +117,7 @@ def compiled_forward_kl_loss(
     rstd = torch.rsqrt(variance + norm_eps)
     norm_hs = (hs_f32 * rstd).to(hs.dtype) * norm_weight
 
-    logits = F.linear(norm_hs, lm_head_weight)  # (N, V_out)
+    logits = _project(norm_hs, lm_head_weight, lm_head_up)  # (N, V_out)
 
     token_loss = _forward_kl_from_logits(logits, tp)
     correct = (logits.argmax(-1) == tp.argmax(-1)).float()
@@ -115,6 +132,7 @@ def compiled_lk_alpha_loss(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     norm_eps,
     coverage_flat,
 ):
@@ -135,7 +153,7 @@ def compiled_lk_alpha_loss(
     tp_tilde = target_p_flat.index_select(0, valid_idx)
     coverage = coverage_flat.index_select(0, valid_idx)
 
-    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, norm_eps)
+    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, lm_head_up, norm_eps)
     q = _softmax_from_logits(logits)
 
     tp = tp_tilde * coverage.unsqueeze(-1)
@@ -153,6 +171,7 @@ def compiled_lk_lambda_loss(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     norm_eps,
     coverage_flat,
     external_mean_alpha,
@@ -181,7 +200,7 @@ def compiled_lk_lambda_loss(
     tp_tilde = target_p_flat.index_select(0, valid_idx)
     coverage = coverage_flat.index_select(0, valid_idx)
 
-    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, norm_eps)
+    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, lm_head_up, norm_eps)
     q = _softmax_from_logits(logits)
     log_q = F.log_softmax(logits.float(), dim=-1)
 
@@ -206,6 +225,7 @@ def compiled_sum_forward_kl_loss_from_hs(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     target_lm_head_weight,
     norm_eps,
 ):
@@ -220,7 +240,7 @@ def compiled_sum_forward_kl_loss_from_hs(
     rstd = torch.rsqrt(variance + norm_eps)
     norm_hs = (hs_f32 * rstd).to(hs.dtype) * norm_weight
 
-    logits = F.linear(norm_hs, lm_head_weight)
+    logits = _project(norm_hs, lm_head_weight, lm_head_up)
     token_loss = _forward_kl_from_logits(logits, tp)
     correct = (logits.argmax(-1) == target_logits.argmax(-1)).float()
     count = torch.ones_like(token_loss, dtype=torch.float32).sum()
@@ -234,6 +254,7 @@ def compiled_lk_alpha_loss_from_hs(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     target_lm_head_weight,
     norm_eps,
 ):
@@ -244,7 +265,7 @@ def compiled_lk_alpha_loss_from_hs(
     target_logits = F.linear(ths, target_lm_head_weight)
     tp = _softmax_from_logits(target_logits)
 
-    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, norm_eps)
+    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, lm_head_up, norm_eps)
     q = _softmax_from_logits(logits)
 
     alpha = torch.min(tp, q).sum(-1)
@@ -261,6 +282,7 @@ def compiled_lk_lambda_loss_from_hs(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     target_lm_head_weight,
     norm_eps,
     external_mean_alpha,
@@ -274,7 +296,7 @@ def compiled_lk_lambda_loss_from_hs(
     target_logits = F.linear(ths, target_lm_head_weight)
     tp = _softmax_from_logits(target_logits)
 
-    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, norm_eps)
+    logits = _rmsnorm_logits(hs, norm_weight, lm_head_weight, lm_head_up, norm_eps)
     q = _softmax_from_logits(logits)
     log_q = F.log_softmax(logits.float(), dim=-1)
 
@@ -302,6 +324,7 @@ def compiled_forward_kl_loss_from_hs(
     valid_idx,
     norm_weight,
     lm_head_weight,
+    lm_head_up,
     target_lm_head_weight,
     norm_eps,
 ):
@@ -327,7 +350,7 @@ def compiled_forward_kl_loss_from_hs(
     rstd = torch.rsqrt(variance + norm_eps)
     norm_hs = (hs_f32 * rstd).to(hs.dtype) * norm_weight
 
-    logits = F.linear(norm_hs, lm_head_weight)
+    logits = _project(norm_hs, lm_head_weight, lm_head_up)
 
     token_loss = _forward_kl_from_logits(logits, tp)
     correct = (logits.argmax(-1) == target_logits.argmax(-1)).float()


### PR DESCRIPTION
Support low-rank approximation of LM Head.

Paper: **SlimSpec: Low-Rank Draft LM-Head for Accelerated Speculative Decoding**
https://arxiv.org/html/2605.10453v1

Add `lm_head_rank_divisor` to the draft model config. When set, the draft's output projection is stored as two matrices, `lm_head.down` [rank, hidden] and `lm_head.up` [vocab, rank] with rank = hidden // divisor, and the dense [vocab, hidden] product is never materialized.

<img width="1158" height="560" alt="image" src="https://github.com/user-attachments/assets/320cc4e5-c1bd-4406-ae41-8d2f723e8c3c" />

Small training run on 20K data shows it has higher loss, but near frozen head acceptance.