### PR TITLE
feat: anchored EAGLE-3 training

### DIFF
--- a/configs/vllm_qwen3_8b_anchored.yaml
+++ b/configs/vllm_qwen3_8b_anchored.yaml
@@ -1,0 +1,69 @@
+# Anchored Eagle3 for Qwen3-8B: the TTT unroll is evaluated at N sampled anchor
+# positions per sample rather than at every supervised position.
+#
+# Pick N against your data. Anchoring only does work when a sample has more
+# supervised positions than N; on short conversational data a large N is a no-op.
+#
+# Usage:
+#   python -m torchspec.train_entry --config configs/vllm_qwen3_8b_anchored.yaml
+
+model:
+  target_model_path: Qwen/Qwen3-8B
+  trust_remote_code: true
+  # MLA draft. Its keys come from the compressed kv_a/kv_b pair rather than
+  # k_proj/v_proj, which is still pointwise in the layer input, so the anchored path
+  # builds the context K/V for the whole sequence without running attention.
+  draft_model_config: configs/draft_models/qwen3_8b_eagle3_mla.json
+
+dataset:
+  train_data_path: ../examples/data/sample_conversations.jsonl
+  eval_data_path: ../examples/data/eval_conversations.jsonl
+  eval_interval: 250
+  chat_template: qwen
+  prompt_key: conversations
+
+training:
+  # The gathered-query mask has no sdpa path, so anchoring requires flex_attention.
+  attention_backend: flex_attention
+  eagle3_num_anchors: 512
+  micro_batch_size: 1
+  draft_accumulation_steps: 1
+  learning_rate: 1e-4
+  max_concurrent_batches: 1
+  max_grad_norm: 0.5
+  max_seq_length: 16384
+  num_epochs: 1
+  seed: 42
+  training_num_gpus_per_node: 2
+  training_num_nodes: 1
+  ttt_length: 7
+  save_per_epoch: true
+  warmup_ratio: 0.015
+
+inference:
+  inference_engine_type: vllm
+  inference_num_gpus: 2
+  inference_num_gpus_per_engine: 2
+  inference_num_gpus_per_node: 4
+  max_sample_pool_size: 64
+  inference_buffer_threshold: 32
+  inference_batch_size: 4
+  vllm:
+    tp_size: 2
+    mem_fraction_static: 0.7
+    extra_args:
+      max_num_batched_tokens: 8192
+
+mooncake:
+  master_server_address: null
+  metadata_server: null
+  protocol: tcp
+  global_segment_size: 32GB
+  local_buffer_size: 4GB
+
+output_dir: ./outputs/qwen3-8b-anchored
+cache_dir: ./cache
+model_download_dir: null
+
+logging:
+  report_to: none

--- a/tests/test_anchored_eagle3.py
+++ b/tests/test_anchored_eagle3.py
@@ -1,0 +1,415 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Anchored Eagle3: the gathered-query mask, and the model plumbing around it."""
+
+import unittest
+import unittest.mock
+
+import torch
+
+from torchspec.models.anchored_eagle3 import AnchoredEagle3Model, anchored_bool_mask
+from torchspec.models.draft.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from torchspec.models.draft.deepseek_eagle import Eagle3DeepseekV2ForCausalLM
+from torchspec.models.eagle3 import Eagle3Model, LazyTarget, PrecomputedTarget
+from torchspec.models.ops.anchors import sample_anchor_positions
+from torchspec.models.ops.flex_attention import generate_eagle3_mask
+
+S, N, T = 12, 4, 4
+ANCHORS = torch.tensor([[2, 5, 8, 10]])
+KEEP = torch.tensor([[True, True, True, True]])
+
+_EAGLE3 = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "model_type": "llama",
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "vocab_size": 128,
+    "max_position_embeddings": 256,
+    "rms_norm_eps": 1e-6,
+    "rope_theta": 10000.0,
+    "pad_token_id": 0,
+    "tie_word_embeddings": False,
+}
+
+
+def _mla_draft():
+    """A DeepSeek-style draft: keys come from the compressed kv_a/kv_b pair."""
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+    config = DeepseekV3Config(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=256,
+        max_position_embeddings=1024,
+        vocab_size=128,
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+        pad_token_id=0,
+        q_lora_rank=48,
+        kv_lora_rank=32,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        num_hidden_layers=1,
+        n_routed_experts=1,
+        n_shared_experts=0,
+        first_k_dense_replace=0,
+        num_experts_per_tok=1,
+    )
+    config.draft_vocab_size = 128
+    config.target_hidden_size = 64
+    return Eagle3DeepseekV2ForCausalLM(config, attention_backend="sdpa").cuda().float()
+
+
+def _mask(anchors, keep, kv_len):
+    """[N, KV] view of the anchored mask for one batch element."""
+    return anchored_bool_mask(anchors, keep, S, N, kv_len)[0, 0]
+
+
+class TestAnchoredMask(unittest.TestCase):
+    def test_context_rows_match_the_dense_eagle3_mask(self):
+        """Anchor a must see exactly what dense position a sees in the context block."""
+        q = torch.arange(S).view(-1, 1).expand(S, 2 * S)
+        kv = torch.arange(2 * S).view(1, -1).expand(S, 2 * S)
+        dense = generate_eagle3_mask(Q_LEN=S, KV_LEN=2 * S, lck=1)(
+            torch.tensor(0), torch.tensor(0), q, kv
+        )
+        anchored = _mask(ANCHORS, KEEP, S + N)
+
+        for slot, position in enumerate(ANCHORS[0].tolist()):
+            torch.testing.assert_close(anchored[slot, :S], dense[position, :S])
+
+    def test_each_anchor_sees_only_its_own_chain_slot(self):
+        depth = 2
+        anchored = _mask(ANCHORS, KEEP, S + depth * N)
+
+        chain = anchored[:, S:]
+        for block in range(depth):
+            torch.testing.assert_close(
+                chain[:, block * N : (block + 1) * N], torch.eye(N, dtype=torch.bool)
+            )
+
+    def test_keep_mask_blanks_a_padded_anchor(self):
+        keep = torch.tensor([[True, False, True, True]])
+        anchored = _mask(ANCHORS, keep, S + N)
+
+        self.assertFalse(anchored[1].any())
+        self.assertTrue(anchored[0].any())
+
+
+class TestAnchoredModel(unittest.TestCase):
+    def _batch(self, bsz=1, seq=64, hidden=64):
+        return dict(
+            input_ids=torch.randint(0, 128, (bsz, seq), device="cuda"),
+            attention_mask=None,
+            target=PrecomputedTarget(
+                target_p_padded=torch.softmax(torch.randn(bsz, seq + T, 128, device="cuda"), dim=-1)
+            ),
+            loss_mask=torch.ones(bsz, seq, device="cuda"),
+            hidden_states=torch.randn(bsz, seq, hidden * 3, device="cuda"),
+        )
+
+    def _model(self, **kwargs):
+        torch.manual_seed(0)
+        config = AutoDraftModelConfig.from_dict(dict(_EAGLE3))
+        draft = AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32)
+        return AnchoredEagle3Model(
+            draft_model=draft, length=T, attention_backend="flex_attention", **kwargs
+        )
+
+    def test_rejects_mrope_drafts(self):
+        """MRoPE rotates through apply_multimodal_rotary_pos_emb, which this path does not."""
+        torch.manual_seed(0)
+        config = AutoDraftModelConfig.from_dict(
+            dict(_EAGLE3, rope_scaling={"rope_type": "mrope", "mrope_section": [16, 24, 24]})
+        )
+        draft = AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "MRoPE"):
+            AnchoredEagle3Model(draft_model=draft, length=T, attention_backend="flex_attention")
+
+    def test_rejects_unsupported_loss_types(self):
+        torch.manual_seed(0)
+        config = AutoDraftModelConfig.from_dict(dict(_EAGLE3))
+        draft = AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "forward_kl"):
+            AnchoredEagle3Model(
+                draft_model=draft,
+                length=T,
+                attention_backend="flex_attention",
+                loss_type="lk_alpha",
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "FlexAttention path needs CUDA")
+    def test_mla_draft_with_far_fewer_anchors_than_positions(self):
+        """The rotary table must span the sequence, not the anchor count.
+
+        MLA's own _apply_rope_and_assemble sizes cos/sin from its query length. Here that
+        is num_anchors (4) while anchors reach position 63, so reusing it indexed off the
+        end of the table -- a device-side assert in training and invisible whenever a test
+        gives num_anchors and seq_len the same size.
+        """
+        model = AnchoredEagle3Model(
+            draft_model=_mla_draft(), length=T, attention_backend="sdpa", num_anchors=N
+        ).cuda()
+
+        plosses, *_ = model(**self._batch(seq=64))
+
+        self.assertEqual(len(plosses), T)
+        for loss in plosses:
+            self.assertTrue(torch.isfinite(loss))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "FlexAttention path needs CUDA")
+    def test_lazy_target_path(self):
+        """Full-vocab configs use LazyTarget; PrecomputedTarget only appears with pruning."""
+        model = self._model(num_anchors=N).cuda()
+        bsz, seq, hidden = 1, 64, 64
+        ids = torch.randint(0, 128, (bsz, seq), device="cuda")
+        aux = torch.randn(bsz, seq, hidden * model.draft_model.num_aux_hidden_states, device="cuda")
+        target = LazyTarget(
+            hidden_states_padded=torch.randn(bsz, seq + T, hidden, device="cuda"),
+            lm_head_weight=torch.randn(128, hidden, device="cuda"),
+        )
+
+        plosses, *_ = model(
+            input_ids=ids,
+            attention_mask=None,
+            target=target,
+            loss_mask=torch.ones(bsz, seq, device="cuda"),
+            hidden_states=aux,
+        )
+
+        self.assertEqual(len(plosses), T)
+        for loss in plosses:
+            self.assertTrue(torch.isfinite(loss))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "FlexAttention path needs CUDA")
+    def test_every_trainable_parameter_receives_a_gradient(self):
+        """A disconnected component would train silently; assert the whole graph is live."""
+        model = self._model(num_anchors=N).cuda()
+        model.draft_model.freeze_embedding()
+
+        sum(model(**self._batch())[0]).backward()
+
+        missing, nonfinite = [], []
+        for name, param in model.named_parameters():
+            if not param.requires_grad:
+                continue
+            if param.grad is None or not param.grad.any():
+                missing.append(name)
+            elif not torch.isfinite(param.grad).all():
+                nonfinite.append(name)
+        self.assertEqual(missing, [], f"no gradient reached: {missing}")
+        self.assertEqual(nonfinite, [], f"non-finite gradient: {nonfinite}")
+
+    @unittest.skipUnless(torch.cuda.is_available(), "FlexAttention path needs CUDA")
+    def test_each_depth_contributes_gradient(self):
+        """Every TTT depth must be differentiable on its own, not just the sum."""
+        for depth in range(T):
+            model = self._model(num_anchors=N).cuda()
+            model.draft_model.freeze_embedding()
+
+            model(**self._batch())[0][depth].backward()
+
+            grad = model.draft_model.midlayer.self_attn.q_proj.weight.grad
+            self.assertIsNotNone(grad, f"depth {depth} produced no gradient")
+            self.assertTrue(torch.isfinite(grad).all() and grad.any(), f"depth {depth}")
+
+
+class TestMatchesDense(unittest.TestCase):
+    """Anchored must be a faithful reimplementation of the dense TTT unroll.
+
+    With every supervised position selected as an anchor, the two paths supervise the
+    same positions at every depth >= 1 and must agree numerically. Depth 0 is excluded
+    only because dense also supervises the one trailing position that cannot be an
+    anchor (an anchor needs ``loss_mask[a] & loss_mask[a + 1]``).
+    """
+
+    def _llama_draft(self):
+        config = AutoDraftModelConfig.from_dict(dict(_EAGLE3))
+        return AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32).cuda()
+
+    def test_per_depth_losses_match_dense(self):
+        for name in ("llama", "mla"):
+            with self.subTest(draft=name):
+                self._assert_matches_dense(name)
+
+    def _assert_matches_dense(self, draft_kind):
+        torch.manual_seed(0)
+        seq, hidden, supervised = 64, 64, 40
+
+        draft = self._llama_draft() if draft_kind == "llama" else _mla_draft()
+
+        # Supervise a prefix so that the anchor set is exactly {0 .. supervised - 2}:
+        # num_anchors exceeds the candidate count, so sampling is deterministic.
+        loss_mask = torch.zeros(1, seq, device="cuda")
+        loss_mask[:, :supervised] = 1.0
+        batch = dict(
+            input_ids=torch.randint(0, 128, (1, seq), device="cuda"),
+            attention_mask=torch.ones(1, seq, dtype=torch.long, device="cuda"),
+            target=PrecomputedTarget(
+                target_p_padded=torch.softmax(torch.randn(1, seq + T, 128, device="cuda"), dim=-1)
+            ),
+            loss_mask=loss_mask,
+            hidden_states=torch.randn(1, seq, hidden * 3, device="cuda"),
+        )
+
+        # "sdpa" so the dense path builds the additive decoder mask its eager attention
+        # needs; the anchored path builds its own mask either way.
+        shared = dict(draft_model=draft, length=T, attention_backend="sdpa")
+        dense = Eagle3Model(**shared)
+        anchored = AnchoredEagle3Model(num_anchors=seq, **shared)
+
+        _, dense_losses, dense_acc, _, _ = dense(**batch)
+        _, anch_losses, anch_acc, _, _ = anchored(**batch)
+
+        for depth in range(1, T):
+            self.assertTrue(
+                torch.allclose(dense_losses[depth], anch_losses[depth], atol=1e-4),
+                f"depth {depth}: dense {dense_losses[depth].item():.6f} "
+                f"vs anchored {anch_losses[depth].item():.6f}",
+            )
+            self.assertTrue(
+                torch.allclose(dense_acc[depth], anch_acc[depth], atol=1e-4),
+                f"depth {depth} accuracy",
+            )
+
+
+def _depth_coverage(anchors, keep, loss_mask, seq, ttt):
+    """(fraction of supervised tokens seen at every depth, mean depths per token)."""
+    from collections import defaultdict
+
+    seen = defaultdict(set)
+    for a in anchors[0][keep[0]].tolist():
+        for depth in range(ttt):
+            target = min(a + depth, seq - 1)
+            if loss_mask[0, target] > 0.5:
+                seen[target].add(depth)
+    if not seen:
+        return 0.0, 0.0
+    counts = [len(v) for v in seen.values()]
+    return sum(c == ttt for c in counts) / len(counts), sum(counts) / len(counts)
+
+
+class TestAnchorGap(unittest.TestCase):
+    """``max_gap`` caps how many supervised positions sit between neighbouring anchors.
+
+    Anchor ``a`` supervises token ``a + d`` at depth ``d``, so a token is seen at depth
+    ``d`` only if the anchor ``d`` positions behind it was also picked. A gap of ``g``
+    leaves each token ``ttt_length / (g + 1)`` of its depths; once ``g`` reaches
+    ``ttt_length`` every token is pinned to a single depth. ``None`` means ``block_size``,
+    which is what DFlash and the dense-vocabulary paths take.
+    """
+
+    TTT = 4
+
+    def _mask(self, seq, supervised):
+        m = torch.zeros(1, seq)
+        m[:, :supervised] = 1.0
+        return m
+
+    def _kept(self, seq, supervised, n, ttt=None, **kw):
+        mask = self._mask(seq, supervised)
+        anchors, keep = sample_anchor_positions(seq, mask, n, ttt or self.TTT, "cpu", **kw)
+        return mask, sorted(anchors[0][keep[0]].tolist())
+
+    def _spacings(self, kept):
+        """Gaps between neighbours, dropping the single seam where the window wraps."""
+        diffs = sorted(b - a for a, b in zip(kept, kept[1:]))
+        return set(diffs[:-1]) or set(diffs)
+
+    def test_gap_sets_the_spacing_between_anchors(self):
+        for gap in (0, 2):
+            _, kept = self._kept(4096, 3000, 128, max_gap=gap)
+            self.assertEqual(self._spacings(kept), {gap + 1}, f"max_gap={gap}")
+
+    def test_default_gap_spreads_anchors_but_never_past_block_size(self):
+        # valid // num_anchors == 2, well under the cap, so anchors span the whole sample
+        _, spread = self._kept(2048, 1500, 512, ttt=16)
+        self.assertEqual(self._spacings(spread), {2})
+
+        # here the even stride would be 124, so the block_size cap binds instead
+        _, capped = self._kept(8192, 8000, 64, ttt=16)
+        self.assertEqual(self._spacings(capped), {17})
+
+    def test_gap_zero_restores_depth_coverage(self):
+        seq, supervised, n = 2048, 1500, 128
+        mask = self._mask(seq, supervised)
+
+        pinned = sample_anchor_positions(seq, mask, n, self.TTT, "cpu")  # None -> ttt_length
+        adjacent = sample_anchor_positions(seq, mask, n, self.TTT, "cpu", max_gap=0)
+
+        full_pinned, mean_pinned = _depth_coverage(*pinned, mask, seq, self.TTT)
+        full_adjacent, mean_adjacent = _depth_coverage(*adjacent, mask, seq, self.TTT)
+
+        self.assertEqual(full_pinned, 0.0, "the default gap pins every token to one depth")
+        self.assertAlmostEqual(mean_pinned, 1.0, delta=0.05)
+        self.assertGreater(full_adjacent, 0.9, f"max_gap=0 covers nearly all, got {full_adjacent}")
+        self.assertGreater(mean_adjacent, mean_pinned)
+
+    def test_every_valid_position_is_used_when_the_budget_allows(self):
+        for gap in (None, 0, 4):
+            _, kept = self._kept(512, 200, 512, max_gap=gap)
+            self.assertEqual(kept, list(range(199)), f"max_gap={gap}")
+
+    def test_window_wraps_so_every_candidate_stays_reachable(self):
+        """The phase is drawn over every candidate and the window wraps past the end.
+
+        Clamping the phase to the leftover slack instead would make the window a fixed
+        interval whose centre is picked almost always and whose ends almost never: with
+        700 candidates and 512 anchors the middle came out at 100% and the edges at 0.5%,
+        against a flat 512/700 for uniform sampling. Wrapping restores the flat marginal.
+        """
+        seq, supervised, n = 1024, 701, 512
+        mask = torch.zeros(1, seq)
+        mask[:, :supervised] = 1.0
+        valid = supervised - 1  # 700 candidates, stride 1, so the window spans 512 of them
+
+        # Force the phase to the far end of the candidate list.
+        with unittest.mock.patch("torch.rand", lambda *shape, **kw: torch.full(shape, 0.99)):
+            anchors, keep = sample_anchor_positions(seq, mask, n, 16, "cpu")
+
+        kept = sorted(anchors[0][keep[0]].tolist())
+        self.assertEqual(len(kept), n)
+        self.assertEqual(kept[-1], valid - 1, "the last candidate must be reachable")
+        self.assertEqual(kept[0], 0, "and the window must wrap round to the first")
+
+    def test_never_selects_unsupervised_positions(self):
+        # two supervised spans with a hole, as in a multi-turn conversation
+        mask = torch.zeros(1, 2048)
+        mask[:, 100:700] = 1.0
+        mask[:, 1200:1800] = 1.0
+
+        for gap in (None, 0, 1, 4):
+            anchors, keep = sample_anchor_positions(2048, mask, 128, self.TTT, "cpu", max_gap=gap)
+            for a in anchors[0][keep[0]].tolist():
+                self.assertTrue(
+                    mask[0, a] > 0.5 and mask[0, a + 1] > 0.5, f"gap={gap}: anchor {a} invalid"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -1267,10 +1267,15 @@ class TestDFlashTrainingQuality(unittest.TestCase):
         self.assertLess(losses[-1], losses[0])
 
     def test_accuracy_improves(self):
-        """Accuracy should improve over training when overfitting on a small batch."""
+        """Accuracy should improve over training when overfitting on a small batch.
+
+        30 steps left the accuracy in the noise -- it improved on only 9 of 12 seeds, so
+        the assertion turned on which anchors happened to be drawn rather than on whether
+        the model learned. 100 steps improves on every seed by at least 0.18.
+        """
         torch.manual_seed(42)
         model, *data = self._make_model_and_data(seq_len=64, batch_size=1)
-        _, accs = self._train_steps(model, *data, steps=30)
+        _, accs = self._train_steps(model, *data, steps=100)
         avg_first5 = sum(accs[:5]) / 5
         avg_last5 = sum(accs[-5:]) / 5
         self.assertGreater(

--- a/tools/bench_anchored_attention.py
+++ b/tools/bench_anchored_attention.py
@@ -33,6 +33,8 @@ def _compiled_builder():
 
 
 DEPTHS, HEADS, KV_HEADS, HEAD_DIM = 7, 32, 8, 128  # DEPTHS overridden by --depths
+QK_DIM, V_DIM = HEAD_DIM, HEAD_DIM  # MLA splits these: 192 for Q/K, 128 for V
+B16 = torch.bfloat16
 
 
 def _mask_mod(anchors, keep, ctx_len, num_anchors):
@@ -81,13 +83,11 @@ def _dense_step(seq, query, cache, device):
 
 def measure(kind, seq, num_anchors, device, reps, warmup, layers=1):
     if kind == "dense-ttt":
-        query = torch.randn(1, HEADS, seq, HEAD_DIM, device=device, dtype=torch.bfloat16)
+        query = torch.randn(1, HEADS, seq, QK_DIM, device=device, dtype=torch.bfloat16)
         cache = [
-            tuple(
-                torch.randn(
-                    1, KV_HEADS, seq * (d + 1), HEAD_DIM, device=device, dtype=torch.bfloat16
-                )
-                for _ in range(2)
+            (
+                torch.randn(1, KV_HEADS, seq * (d + 1), QK_DIM, device=device, dtype=B16),
+                torch.randn(1, KV_HEADS, seq * (d + 1), V_DIM, device=device, dtype=B16),
             )
             for d in range(DEPTHS)
         ]
@@ -96,25 +96,18 @@ def measure(kind, seq, num_anchors, device, reps, warmup, layers=1):
         anchors = torch.sort(torch.randperm(seq - DEPTHS, device=device)[:num_anchors]).values
         anchors = anchors.unsqueeze(0)
         keep = torch.ones(1, num_anchors, dtype=torch.bool, device=device)
-        query = torch.randn(1, HEADS, num_anchors, HEAD_DIM, device=device, dtype=torch.bfloat16)
+        query = torch.randn(1, HEADS, num_anchors, QK_DIM, device=device, dtype=torch.bfloat16)
         cache = [
-            tuple(
-                torch.randn(
-                    1,
-                    KV_HEADS,
-                    seq + d * num_anchors,
-                    HEAD_DIM,
-                    device=device,
-                    dtype=torch.bfloat16,
-                )
-                for _ in range(2)
+            (
+                torch.randn(1, KV_HEADS, seq + d * num_anchors, QK_DIM, device=device, dtype=B16),
+                torch.randn(1, KV_HEADS, seq + d * num_anchors, V_DIM, device=device, dtype=B16),
             )
             for d in range(DEPTHS)
         ]
         args = (anchors, keep, seq, num_anchors, query, cache, device)
         # With more than one layer the depth-0 context K/V are no longer pointwise: layer L
         # needs layer L-1 outputs at every position, so depth 0 becomes a dense pass per layer.
-        dense_q = torch.randn(1, HEADS, seq, HEAD_DIM, device=device, dtype=torch.bfloat16)
+        dense_q = torch.randn(1, HEADS, seq, QK_DIM, device=device, dtype=torch.bfloat16)
         dense_kv = cache[0]
 
         def run():
@@ -139,12 +132,18 @@ KINDS = ["dense-ttt", "sdpa", "flex+blockmask"]
 
 
 def main():
-    global DEPTHS
+    global DEPTHS, KV_HEADS, QK_DIM, V_DIM
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--seq", type=int, nargs="+", default=[384, 4096, 16384])
     parser.add_argument("--anchors", type=int, nargs="+", default=[128, 256])
     parser.add_argument("--depths", type=int, default=7, help="ttt_length")
     parser.add_argument("--layers", type=int, default=1, help="draft decoder layers")
+    parser.add_argument(
+        "--mla",
+        action="store_true",
+        help="MLA head shape: keys carry qk_nope+qk_rope (192) and values v_head_dim "
+        "(128), across all heads rather than a smaller KV group",
+    )
     parser.add_argument(
         "--kinds", nargs="+", default=KINDS, choices=KINDS, help="strategies to measure"
     )
@@ -158,6 +157,8 @@ def main():
         "would otherwise inherit, which silently equalises them.",
     )
     args = parser.parse_args()
+    if args.mla:
+        KV_HEADS, QK_DIM, V_DIM = HEADS, 192, 128
     DEPTHS = args.depths
 
     if args.kind:
@@ -191,6 +192,7 @@ def main():
                 *map(str, args.seq),
                 "--anchors",
                 *map(str, args.anchors),
+                *(["--mla"] if args.mla else []),
             ],
             capture_output=True,
             text=True,

--- a/tools/bench_anchored_attention.py
+++ b/tools/bench_anchored_attention.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Compare masking strategies for anchored Eagle3 attention.
+
+    python tools/bench_anchored_attention.py --seq 384 4096 16384 --anchors 128 256
+
+Anchored attention is small (Q = num_anchors), so the usual block-sparse machinery can cost
+more than the density it removes. This measures that trade-off directly.
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+
+import torch
+import torch.nn.functional as F
+from torch.nn.attention.flex_attention import create_block_mask
+
+from torchspec.models.anchored_eagle3 import anchored_bool_mask
+from torchspec.models.ops.flex_attention import (
+    compile_friendly_create_block_mask,
+    compile_friendly_flex_attention,
+)
+
+_compiled_create_block_mask = None
+
+
+def _compiled_builder():
+    global _compiled_create_block_mask
+    if _compiled_create_block_mask is None:
+        _compiled_create_block_mask = torch.compile(create_block_mask, dynamic=True)
+    return _compiled_create_block_mask
+
+
+DEPTHS, HEADS, KV_HEADS, HEAD_DIM = 7, 32, 8, 128  # DEPTHS overridden by --depths
+
+
+def _mask_mod(anchors, keep, ctx_len, num_anchors):
+    """BlockMask form of the anchored predicate, for the flex comparison only.
+
+    The shipped model uses anchored_bool_mask; this exists so the benchmark can measure what
+    the BlockMask path would cost.
+    """
+
+    def mask_mod(b, h, q_idx, kv_idx):
+        anchor = anchors[b, q_idx]
+        context = (kv_idx < ctx_len) & (kv_idx <= anchor)
+        chain = (kv_idx >= ctx_len) & (((kv_idx - ctx_len) % num_anchors) == q_idx)
+        return (context | chain) & keep[b, q_idx]
+
+    return mask_mod
+
+
+def _step(kind, anchors, keep, seq, num_anchors, query, cache, device):
+    """One TTT unroll: an attention call per depth over a KV cache that grows by num_anchors."""
+    mask_mod = _mask_mod(anchors, keep, seq, num_anchors)
+    for key, value in cache:
+        kv_len = key.shape[2]
+        if kind == "sdpa":
+            mask = anchored_bool_mask(anchors, keep, seq, num_anchors, kv_len)
+            F.scaled_dot_product_attention(query, key, value, attn_mask=mask, enable_gqa=True)
+        else:
+            block = compile_friendly_create_block_mask(mask_mod, 1, 1, num_anchors, kv_len, device)
+            compile_friendly_flex_attention(
+                query=query, key=key, value=value, block_mask=block, enable_gqa=True
+            )
+
+
+def _dense_step(seq, query, cache, device):
+    """Dense TTT attention: every position is a query, KV grows by seq each depth."""
+    from torchspec.models.ops.flex_attention import eagle3_block_mask
+
+    for depth, (key, value) in enumerate(cache):
+        block = eagle3_block_mask(
+            Q_LEN=seq, KV_LEN=key.shape[2], B=1, H=1, device=device, lck=depth
+        )
+        compile_friendly_flex_attention(
+            query=query, key=key, value=value, block_mask=block, enable_gqa=True
+        )
+
+
+def measure(kind, seq, num_anchors, device, reps, warmup, layers=1):
+    if kind == "dense-ttt":
+        query = torch.randn(1, HEADS, seq, HEAD_DIM, device=device, dtype=torch.bfloat16)
+        cache = [
+            tuple(
+                torch.randn(
+                    1, KV_HEADS, seq * (d + 1), HEAD_DIM, device=device, dtype=torch.bfloat16
+                )
+                for _ in range(2)
+            )
+            for d in range(DEPTHS)
+        ]
+        run = lambda: [_dense_step(seq, query, cache, device) for _ in range(layers)]  # noqa: E731
+    else:
+        anchors = torch.sort(torch.randperm(seq - DEPTHS, device=device)[:num_anchors]).values
+        anchors = anchors.unsqueeze(0)
+        keep = torch.ones(1, num_anchors, dtype=torch.bool, device=device)
+        query = torch.randn(1, HEADS, num_anchors, HEAD_DIM, device=device, dtype=torch.bfloat16)
+        cache = [
+            tuple(
+                torch.randn(
+                    1,
+                    KV_HEADS,
+                    seq + d * num_anchors,
+                    HEAD_DIM,
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+                for _ in range(2)
+            )
+            for d in range(DEPTHS)
+        ]
+        args = (anchors, keep, seq, num_anchors, query, cache, device)
+        # With more than one layer the depth-0 context K/V are no longer pointwise: layer L
+        # needs layer L-1 outputs at every position, so depth 0 becomes a dense pass per layer.
+        dense_q = torch.randn(1, HEADS, seq, HEAD_DIM, device=device, dtype=torch.bfloat16)
+        dense_kv = cache[0]
+
+        def run():
+            for _ in range(layers):
+                if layers > 1:
+                    _dense_step(seq, dense_q, [dense_kv], device)
+                _step(kind, *args)
+
+    for _ in range(warmup):
+        run()
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    start = time.perf_counter()
+    for _ in range(reps):
+        run()
+    torch.cuda.synchronize()
+    elapsed = (time.perf_counter() - start) / reps * 1000
+    return elapsed, torch.cuda.max_memory_allocated() / 1e9
+
+
+KINDS = ["dense-ttt", "sdpa", "flex+blockmask"]
+
+
+def main():
+    global DEPTHS
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seq", type=int, nargs="+", default=[384, 4096, 16384])
+    parser.add_argument("--anchors", type=int, nargs="+", default=[128, 256])
+    parser.add_argument("--depths", type=int, default=7, help="ttt_length")
+    parser.add_argument("--layers", type=int, default=1, help="draft decoder layers")
+    parser.add_argument(
+        "--kinds", nargs="+", default=KINDS, choices=KINDS, help="strategies to measure"
+    )
+    parser.add_argument("--reps", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument(
+        "--kind",
+        choices=KINDS,
+        help="Measure one strategy and print 'seq anchors kind ms'. Without it, each strategy "
+        "is measured in its own subprocess: compiling one warms inductor state the others "
+        "would otherwise inherit, which silently equalises them.",
+    )
+    args = parser.parse_args()
+    DEPTHS = args.depths
+
+    if args.kind:
+        for seq in args.seq:
+            for num_anchors in args.anchors:
+                if num_anchors > seq - DEPTHS:
+                    continue
+                ms, peak = measure(
+                    args.kind, seq, num_anchors, "cuda", args.reps, args.warmup, args.layers
+                )
+                print(f"RESULT {seq} {num_anchors} {args.kind} {ms:.3f} {peak:.3f}")
+        return
+
+    results = {}
+    for kind in args.kinds:
+        out = subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--kind",
+                kind,
+                "--depths",
+                str(args.depths),
+                "--layers",
+                str(args.layers),
+                "--reps",
+                str(args.reps),
+                "--warmup",
+                str(args.warmup),
+                "--seq",
+                *map(str, args.seq),
+                "--anchors",
+                *map(str, args.anchors),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        for line in out.stdout.splitlines():
+            if line.startswith("RESULT"):
+                _, seq, anch, k, ms, peak = line.split()
+                results[(int(seq), int(anch), k)] = (float(ms), float(peak))
+
+    header = f"{'seq':>7} {'anch':>5}  " + "".join(f"{k:>26}" for k in args.kinds)
+    print(header)
+    print(f"{'':>7} {'':>5}  " + "".join(f"{'ms / peak GB':>26}" for _ in args.kinds))
+    for seq in args.seq:
+        for num_anchors in args.anchors:
+            row = {k: results.get((seq, num_anchors, k)) for k in args.kinds}
+            if not any(row.values()):
+                continue
+            cells = "".join(
+                f"{v[0]:>14.2f} /{v[1]:>8.2f}" if v else f"{'n/a':>26}" for v in row.values()
+            )
+            print(f"{seq:>7} {num_anchors:>5}  {cells}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -103,6 +103,8 @@ class TrainingConfig:
     distributed_backend: str = "nccl"
     distributed_timeout_minutes: int = 10
     draft_accumulation_steps: int = 1
+    eagle3_num_anchors: int = 0
+    eagle3_anchor_max_gap: Optional[int] = None
     fsdp_reduce_dtype: str = "float32"  # "float32" or "bfloat16"
     fsdp_strategy: str = "REPLICATE"
     # Controls which workload claims head-node GPUs first under PACK strategy.

--- a/torchspec/models/anchored_eagle3.py
+++ b/torchspec/models/anchored_eagle3.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Anchored Eagle3: run the TTT unroll at N sampled positions instead of all of them.
+
+The draft is a single layer, so its depth-0 keys and values are a pointwise projection of
+the layer input and can be built for the whole sequence without any attention. Only the
+queries are gathered, which is what makes every depth cost O(N) rather than O(S).
+"""
+
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+
+from torchspec.models.draft.deepseek_eagle import _apply_rotary_pos_emb_interleaved
+from torchspec.models.draft.llama3_eagle import (
+    LlamaMutiRotaryEmbedding,
+    apply_rotary_pos_emb,
+)
+from torchspec.models.eagle3 import Eagle3Model, LazyTarget, PrecomputedTarget
+from torchspec.models.ops.anchors import sample_anchor_positions
+
+
+def _anchored_allows(
+    anchor_positions: torch.Tensor,
+    keep_mask: torch.Tensor,
+    ctx_len: int,
+    num_anchors: int,
+):
+    """Whether anchor ``q_idx`` may attend to ``kv_idx``.
+
+    KV is ``[context (ctx_len) | chain depth 1 | chain depth 2 | ...]`` with ``num_anchors``
+    slots per chain block. An anchor sees the context up to and including its own position,
+    plus its own slot in every chain block written so far. Anchors never see each other.
+    """
+
+    def allows(b, q_idx, kv_idx):
+        anchor = anchor_positions[b, q_idx]
+        context = (kv_idx < ctx_len) & (kv_idx <= anchor)
+        chain = (kv_idx >= ctx_len) & (((kv_idx - ctx_len) % num_anchors) == q_idx)
+        return (context | chain) & keep_mask[b, q_idx]
+
+    return allows
+
+
+def anchored_bool_mask(
+    anchor_positions: torch.Tensor,
+    keep_mask: torch.Tensor,
+    ctx_len: int,
+    num_anchors: int,
+    kv_len: int,
+) -> torch.Tensor:
+    """The predicate as a [B, 1, N, KV] boolean mask for scaled_dot_product_attention.
+
+    Two broadcasts. Anchored attention is small enough that a BlockMask costs more to build
+    than the density it removes: at S=4096 with 4 depths the build alone is 2.1ms against
+    1.2ms for this whole path.
+    """
+    kv = torch.arange(kv_len, device=anchor_positions.device)
+    slot = torch.arange(num_anchors, device=anchor_positions.device).unsqueeze(-1)
+    context = (kv < ctx_len) & (kv <= anchor_positions.unsqueeze(-1))
+    chain = (kv >= ctx_len) & (((kv - ctx_len) % num_anchors) == slot)
+    return ((context | chain) & keep_mask.unsqueeze(-1)).unsqueeze(1)
+
+
+def _gather(source: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+    """Gather along the sequence dim: [B, S(, D)] by [B, N] -> [B, N(, D)]."""
+    if source.dim() == 2:
+        return torch.gather(source, 1, index)
+    return torch.gather(source, 1, index.unsqueeze(-1).expand(-1, -1, source.shape[-1]))
+
+
+def _heads(projected: torch.Tensor, num_heads: int, head_dim: int) -> torch.Tensor:
+    bsz, length, _ = projected.shape
+    return projected.view(bsz, length, num_heads, head_dim).transpose(1, 2)
+
+
+def _gather_target(
+    target: Union[PrecomputedTarget, LazyTarget], positions: torch.Tensor
+) -> Union[PrecomputedTarget, LazyTarget]:
+    """Restrict a target to the anchor positions for one depth.
+
+    Gathering N rows is cheaper than the dense path's [:, idx : idx + seq_len] slice, so the
+    loss reads the same either way with idx=0 and seq_length=num_anchors.
+    """
+    if isinstance(target, PrecomputedTarget):
+        return PrecomputedTarget(target_p_padded=_gather(target.target_p_padded, positions))
+    return LazyTarget(
+        hidden_states_padded=_gather(target.hidden_states_padded, positions),
+        lm_head_weight=target.lm_head_weight,
+    )
+
+
+class AnchoredEagle3Model(Eagle3Model):
+    """Eagle3 whose TTT depths are evaluated at sampled anchors rather than every position."""
+
+    def __init__(
+        self,
+        draft_model,
+        *args,
+        num_anchors: int = 512,
+        anchor_max_gap: Optional[int] = None,
+        **kwargs,
+    ):
+        super().__init__(draft_model, *args, **kwargs)
+        self.is_mla = hasattr(draft_model.midlayer.self_attn, "kv_a_proj_with_mqa")
+        if isinstance(draft_model.midlayer.self_attn.rotary_emb, LlamaMutiRotaryEmbedding):
+            raise ValueError(
+                "Anchored Eagle3 does not support MRoPE drafts (rope_scaling.rope_type="
+                "'mrope'). The dense path rotates through apply_multimodal_rotary_pos_emb "
+                "with the configured mrope_section, while the gathered-query path applies "
+                "standard rotary and would ignore the multidimensional position ids."
+            )
+        if self.loss_type != "forward_kl":
+            raise ValueError(
+                f"Anchored Eagle3 supports loss_type='forward_kl', got {self.loss_type!r}."
+            )
+        self.num_anchors = num_anchors
+        self.anchor_max_gap = anchor_max_gap
+
+    def _qkv(self, attn, layer_input, positions, rope, query: bool = True):
+        """(query, key, value) in heads for one set of positions, rotated at ``positions``.
+
+        Both attention shapes are pointwise in the layer input, which is what lets the
+        context K/V be built for the whole sequence without running attention. MLA reaches
+        its keys through the compressed kv_a/kv_b pair rather than k_proj/v_proj, rotates
+        only the rope-side dims, and carries its own softmax scale.
+        """
+        if self.is_mla:
+            q, k_nope, k_rope, value = attn._project_qkv(layer_input)
+            q_nope, q_rope = q.split([attn.qk_nope_head_dim, attn.qk_rope_head_dim], dim=-1)
+            q_rope, k_rope = _apply_rotary_pos_emb_interleaved(
+                q_rope, k_rope, rope[0], rope[1], positions
+            )
+            k_rope = k_rope.expand(-1, attn.num_heads, -1, -1)
+            return torch.cat([q_nope, q_rope], dim=-1), torch.cat([k_nope, k_rope], dim=-1), value
+
+        key = _heads(attn.k_proj(layer_input), attn.num_key_value_heads, attn.head_dim)
+        value = _heads(attn.v_proj(layer_input), attn.num_key_value_heads, attn.head_dim)
+        q = _heads(attn.q_proj(layer_input), attn.num_heads, attn.head_dim) if query else key
+        q, key = apply_rotary_pos_emb(q, key, rope[0], rope[1], positions)
+        return q, key, value
+
+    def _fuse(self, layer, input_emb: torch.Tensor, hidden: torch.Tensor) -> torch.Tensor:
+        """The decoder layer's attention input: norm(embedding) concat norm(hidden)."""
+        return torch.cat((layer.input_layernorm(input_emb), layer.hidden_norm(hidden)), dim=-1)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        target: Union[PrecomputedTarget, LazyTarget],
+        loss_mask: torch.Tensor,
+        hidden_states: torch.Tensor,
+        past_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        position_ids: Optional[torch.Tensor] = None,
+    ):
+        draft = self.draft_model
+        layer = draft.midlayer
+        attn = layer.self_attn
+        bsz, seq_len = input_ids.shape
+        device, num_anchors = input_ids.device, self.num_anchors
+        norm_weight, lm_head_weight, norm_eps = draft.get_lm_head_params()
+        lm_head_up = draft.get_lm_head_up_weight()
+
+        # compute_target_p_padded marks positions whose full-vocab argmax falls outside the
+        # pruned draft vocabulary; the dense path masks on that instead of loss_mask, and
+        # training on those positions would fit a renormalized target the draft cannot emit.
+        effective_mask = loss_mask
+        if isinstance(target, PrecomputedTarget) and target.position_mask is not None:
+            effective_mask = target.position_mask
+
+        anchors, keep_mask = sample_anchor_positions(
+            seq_len, effective_mask, num_anchors, self.length, device, self.anchor_max_gap
+        )
+
+        input_ids = input_ids.clamp(min=0, max=draft.target_vocab_size - 1)
+        projected = draft.project_hidden_states(hidden_states)
+        embeddings = draft.embed_input_ids(input_ids).to(projected.dtype)
+
+        # One rotary table covering every position an anchor can reach. Building it per
+        # call from the query length would size it to num_anchors, not the sequence.
+        cos, sin = attn.rotary_emb(projected, seq_len=seq_len + self.length)
+        rope = (cos.to(device), sin.to(device))
+
+        # Context K/V. One layer means these are pointwise in the layer input, so the whole
+        # sequence is a couple of linears -- no attention, no MLP, no cross-position term.
+        context_positions = torch.arange(seq_len, device=device).expand(bsz, -1)
+        context = self._fuse(layer, embeddings, projected)
+        _, key_cache, value_cache = self._qkv(attn, context, context_positions, rope, query=False)
+
+        current = _gather(projected, anchors)
+
+        plosses, vlosses, acces, acc_counts, alphas = [], [], [], [], []
+        for depth in range(self.length):
+            positions = (anchors + depth).clamp(max=seq_len - 1)
+            fused = self._fuse(layer, _gather(embeddings, positions), current)
+
+            query, key, value = self._qkv(attn, fused, positions, rope)
+
+            # Depth 0's fused input is context[:, anchors], so its keys are already in the
+            # context block; appending them would double-count each anchor's own key.
+            if depth:
+                key_cache = torch.cat([key_cache, key], dim=2)
+                value_cache = torch.cat([value_cache, value], dim=2)
+
+            attn_out = F.scaled_dot_product_attention(
+                query,
+                key_cache,
+                value_cache,
+                attn_mask=anchored_bool_mask(
+                    anchors, keep_mask, seq_len, num_anchors, key_cache.shape[2]
+                ),
+                enable_gqa=not self.is_mla,
+                scale=attn.softmax_scale if self.is_mla else None,
+            )
+            attn_out = attn_out.transpose(1, 2).reshape(bsz, num_anchors, -1)
+
+            hidden = current + attn.o_proj(attn_out)
+            hidden = hidden + layer.mlp(layer.post_attention_layernorm(hidden))
+
+            step_mask = _gather(effective_mask, positions) * keep_mask
+            step_target = _gather_target(target, positions)
+            loss_sum, correct, count, alpha_sum = self._calculate_loss(
+                hidden_states=hidden,
+                target=step_target,
+                mask=step_mask,
+                idx=0,
+                seq_length=num_anchors,
+                norm_weight=norm_weight,
+                lm_head_weight=lm_head_weight,
+                norm_eps=norm_eps,
+                lm_head_up=lm_head_up,
+            )
+            denominator = count.clamp_min(1.0)
+            plosses.append(loss_sum / denominator)
+            vlosses.append((loss_sum / denominator).detach())
+            acces.append((correct / denominator).detach())
+            acc_counts.append(count.detach().float())
+            alphas.append((alpha_sum / denominator).detach())
+
+            current = draft.norm(hidden) if draft.norm_output else hidden
+
+        return plosses, vlosses, acces, acc_counts, alphas

--- a/torchspec/models/anchored_eagle3.py
+++ b/torchspec/models/anchored_eagle3.py
@@ -93,6 +93,18 @@ def _heads(projected: torch.Tensor, num_heads: int, head_dim: int) -> torch.Tens
     return projected.view(bsz, length, num_heads, head_dim).transpose(1, 2)
 
 
+def _mla_kv(attn, layer_input: torch.Tensor):
+    """MLA's K/V halves alone: (k_nope, k_rope_raw, value), skipping the query projection."""
+    bsz, length, _ = layer_input.shape
+    compressed, k_rope = torch.split(
+        attn.kv_a_proj_with_mqa(layer_input), [attn.kv_lora_rank, attn.qk_rope_head_dim], dim=-1
+    )
+    kv = attn.kv_b_proj(attn.kv_a_layernorm(compressed))
+    kv = kv.view(bsz, length, attn.num_heads, attn.qk_nope_head_dim + attn.v_head_dim)
+    k_nope, value = torch.split(kv, [attn.qk_nope_head_dim, attn.v_head_dim], dim=-1)
+    return k_nope.transpose(1, 2), value.transpose(1, 2), k_rope.unsqueeze(1)
+
+
 def _gather_target(
     target: Union[PrecomputedTarget, LazyTarget], positions: torch.Tensor
 ) -> Union[PrecomputedTarget, LazyTarget]:
@@ -145,13 +157,23 @@ class AnchoredEagle3Model(Eagle3Model):
         only the rope-side dims, and carries its own softmax scale.
         """
         if self.is_mla:
-            q, k_nope, k_rope, value = attn._project_qkv(layer_input)
-            q_nope, q_rope = q.split([attn.qk_nope_head_dim, attn.qk_rope_head_dim], dim=-1)
-            q_rope, k_rope = _apply_rotary_pos_emb_interleaved(
-                q_rope, k_rope, rope[0], rope[1], positions
-            )
+            if query:
+                q, k_nope, k_rope, value = attn._project_qkv(layer_input)
+                q_nope, q_rope = q.split([attn.qk_nope_head_dim, attn.qk_rope_head_dim], dim=-1)
+                q_rope, k_rope = _apply_rotary_pos_emb_interleaved(
+                    q_rope, k_rope, rope[0], rope[1], positions
+                )
+                q = torch.cat([q_nope, q_rope], dim=-1)
+            else:
+                # _project_qkv would also run q_a_proj/q_b_proj, which is most of the
+                # projection cost and is thrown away for a context that needs only K/V.
+                k_nope, value, k_rope = _mla_kv(attn, layer_input)
+                _, k_rope = _apply_rotary_pos_emb_interleaved(
+                    k_rope, k_rope, rope[0], rope[1], positions
+                )
+                q = k_rope
             k_rope = k_rope.expand(-1, attn.num_heads, -1, -1)
-            return torch.cat([q_nope, q_rope], dim=-1), torch.cat([k_nope, k_rope], dim=-1), value
+            return q, torch.cat([k_nope, k_rope], dim=-1), value
 
         key = _heads(attn.k_proj(layer_input), attn.num_key_value_heads, attn.head_dim)
         value = _heads(attn.v_proj(layer_input), attn.num_key_value_heads, attn.head_dim)

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -32,8 +32,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from torchspec.models.ops.anchors import sample_anchor_positions
 from torchspec.models.ops.flex_attention import compile_friendly_create_block_mask
-from torchspec.utils.logging import logger
 
 _VALID_DFLASH_LOSS_OBJECTIVES = {"decay", "dpace"}
 
@@ -154,67 +154,9 @@ class DFlashModel(nn.Module):
         loss_mask: torch.Tensor,
         device: torch.device,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Sample anchor positions per sample; returns (anchors, keep_mask).
-
-        Always returns exactly ``self.num_anchors`` anchor slots so that
-        ``Q_LEN = num_anchors * block_size`` is constant across steps,
-        preventing FlexAttention recompilation from shape changes.  Samples
-        with fewer valid positions use ``block_keep_mask=False`` for the
-        excess slots (those blocks are skipped by the block-sparse kernel).
-
-        Args:
-            seq_len: sequence length
-            loss_mask: [B, seq_len] — 1 for valid positions, 0 for padding
-            device: torch device
-
-        Returns:
-            anchors: [B, num_anchors] — sampled anchor positions (sorted)
-            keep_mask: [B, num_anchors] — True for valid sampled anchors
-        """
-        bs = self.block_size
-        bsz = loss_mask.shape[0]
-        max_anchor = max(seq_len - bs, 0)
-        max_n = self.num_anchors
-
-        if max_anchor == 0:
-            logger.warning(
-                f"Sequence too short for anchor sampling (seq_len={seq_len}, "
-                f"block_size={bs}). Returning dummy anchors so loss is zero."
-            )
-            anchors = torch.zeros(bsz, max_n, dtype=torch.long, device=device)
-            keep_mask = torch.zeros(bsz, max_n, dtype=torch.bool, device=device)
-            return anchors, keep_mask
-
-        # An anchor is only usable if its own position and the position right
-        # after it are both supervised: the block's first prediction target is
-        # ``anchor + 1``, so an isolated supervised token yields no gradient.
-        num_candidates = min(max_anchor + 1, seq_len - 1)
-        valid = (loss_mask[:, :num_candidates] > 0.5) & (loss_mask[:, 1 : num_candidates + 1] > 0.5)
-        valid_counts = valid.sum(dim=1)
-
-        indices = torch.arange(num_candidates, device=device).unsqueeze(0).expand(bsz, -1)
-        masked_indices = torch.where(valid, indices, seq_len + 1)
-
-        random_vals = torch.rand(bsz, num_candidates, device=device)
-        random_vals = torch.where(valid, random_vals, 2.0)
-
-        _, sorted_idx = random_vals.sort(dim=1)
-        gathered = torch.gather(masked_indices, 1, sorted_idx)
-
-        # Take up to num_anchors slots; pad with zeros if fewer valid positions
-        take_n = min(max_n, gathered.shape[1])
-        selected = gathered[:, :take_n].sort(dim=1).values
-        if take_n < max_n:
-            pad = torch.zeros(bsz, max_n - take_n, dtype=torch.long, device=device)
-            selected = torch.cat([selected, pad], dim=1)
-        anchors = selected
-
-        keep_mask = torch.arange(max_n, device=device).unsqueeze(0) < valid_counts.unsqueeze(
-            1
-        ).clamp(max=max_n)
-        anchors = torch.where(keep_mask, anchors, 0)
-
-        return anchors, keep_mask
+        return sample_anchor_positions(
+            seq_len, loss_mask, self.num_anchors, self.block_size, device
+        )
 
     def _create_position_ids(
         self, anchor_positions: torch.Tensor, seq_len: int

--- a/torchspec/models/ops/anchors.py
+++ b/torchspec/models/ops/anchors.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Anchor sampling shared by the anchored draft training paths."""
+
+from typing import Optional, Tuple
+
+import torch
+
+from torchspec.utils.logging import logger
+
+
+def _candidates(seq_len: int, loss_mask: torch.Tensor, block_size: int, device: torch.device):
+    """Positions usable as anchors, as (num_candidates, valid, valid_counts, masked_indices).
+
+    An anchor is only usable if its own position and the position right after it are both
+    supervised: the block's first prediction target is ``anchor + 1``, so an isolated
+    supervised token yields no gradient.
+    """
+    bsz = loss_mask.shape[0]
+    max_anchor = max(seq_len - block_size, 0)
+    num_candidates = min(max_anchor + 1, seq_len - 1)
+
+    valid = (loss_mask[:, :num_candidates] > 0.5) & (loss_mask[:, 1 : num_candidates + 1] > 0.5)
+    indices = torch.arange(num_candidates, device=device).unsqueeze(0).expand(bsz, -1)
+    return num_candidates, valid, valid.sum(dim=1), torch.where(valid, indices, seq_len + 1)
+
+
+def _empty(bsz: int, num_anchors: int, seq_len: int, block_size: int, device: torch.device):
+    logger.warning(
+        f"Sequence too short for anchor sampling (seq_len={seq_len}, "
+        f"block_size={block_size}). Returning dummy anchors so loss is zero."
+    )
+    return (
+        torch.zeros(bsz, num_anchors, dtype=torch.long, device=device),
+        torch.zeros(bsz, num_anchors, dtype=torch.bool, device=device),
+    )
+
+
+def sample_anchor_positions(
+    seq_len: int,
+    loss_mask: torch.Tensor,
+    num_anchors: int,
+    block_size: int,
+    device: torch.device,
+    max_gap: Optional[int] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Sample anchor positions per sample; returns (anchors, keep_mask).
+
+    Always returns exactly ``num_anchors`` anchor slots so that
+    ``Q_LEN = num_anchors * block_size`` is constant across steps, preventing
+    FlexAttention recompilation from shape changes. Samples with fewer valid positions
+    leave the excess slots masked off.
+
+    ``max_gap`` is how many supervised positions may sit *between* neighbouring anchors,
+    so ``max_gap=0`` puts them side by side (5, 6, 7, ...). It matters because anchor ``a``
+    supervises token ``a + d`` at unroll depth ``d``: a token is seen at depth ``d`` only if
+    the anchor ``d`` positions behind it was also picked. Anchors with a gap of ``g`` leave
+    each token ``block_size / (g + 1)`` of its depths, so once ``g`` reaches ``block_size``
+    every token is pinned to a single depth.
+
+        max_gap=0     neighbours adjacent; every token in the covered span is supervised
+                      at all ``block_size`` depths, as in the dense unroll
+        max_gap=k     every (k+1)-th supervised position, over a (k+1)x wider span
+        max_gap=None  defaults to ``block_size``: one depth per token
+
+    Gaps count supervised positions, not raw tokens, so slots are never spent on
+    unsupervised regions and anchors stay token-adjacent inside a supervised span.
+
+    Args:
+        seq_len: sequence length
+        loss_mask: [B, seq_len] — 1 for valid positions, 0 for padding
+        device: torch device
+        max_gap: supervised positions permitted between neighbours; None means block_size
+
+    Returns:
+        anchors: [B, num_anchors] — sampled anchor positions (sorted)
+        keep_mask: [B, num_anchors] — True for valid sampled anchors
+    """
+    bsz = loss_mask.shape[0]
+    if max(seq_len - block_size, 0) == 0:
+        return _empty(bsz, num_anchors, seq_len, block_size, device)
+
+    if max_gap is None:
+        max_gap = block_size
+
+    num_candidates, _, valid_counts, masked_indices = _candidates(
+        seq_len, loss_mask, block_size, device
+    )
+    # Supervised positions in order; sentinels sort to the back and are masked off below.
+    ordered = masked_indices.sort(dim=1).values
+
+    # Spread the budget over the whole sample when it reaches, otherwise pack as tightly
+    # as max_gap allows. The window wraps and its phase is drawn over every candidate, so
+    # each one is picked with probability num_anchors / valid_count exactly as uniform
+    # sampling would. Drawing the phase over the leftover slack instead would pick the
+    # middle of a sample far more often than its ends.
+    counts = valid_counts.unsqueeze(1).clamp(min=1)
+    stride = (valid_counts // num_anchors).clamp(min=1, max=max_gap + 1).unsqueeze(1)
+    offset = (torch.rand(bsz, 1, device=device) * counts).long()
+
+    slot = torch.arange(num_anchors, device=device).unsqueeze(0)
+    # num_anchors * stride <= valid_count by construction, so the wrap never collides.
+    rank = (offset + slot * stride) % counts
+    keep_mask = slot < valid_counts.unsqueeze(1)
+    anchors = ordered.gather(1, rank.clamp(max=num_candidates - 1))
+    return torch.where(keep_mask, anchors, 0), keep_mask

--- a/torchspec/training/eagle3_trainer.py
+++ b/torchspec/training/eagle3_trainer.py
@@ -25,6 +25,7 @@ import torch
 import torch.distributed as dist
 
 from torchspec import AutoDraftModelConfig, AutoEagle3DraftModel, Eagle3Model
+from torchspec.models.anchored_eagle3 import AnchoredEagle3Model
 from torchspec.models.eagle3 import compute_lazy_target_padded, compute_target_p_padded
 from torchspec.training import checkpoint
 from torchspec.training.fsdp import apply_fsdp2, fsdp2_load_full_state_dict
@@ -132,7 +133,9 @@ class Eagle3Trainer(Trainer):
             f"{frozen_count:,} frozen ({', '.join(frozen_parts)}) parameters"
         )
 
-        eagle3_model = Eagle3Model(
+        num_anchors = getattr(self.args, "eagle3_num_anchors", 0)
+        anchor_max_gap = getattr(self.args, "eagle3_anchor_max_gap", None)
+        model_kwargs = dict(
             draft_model=draft_model,
             length=self.args.ttt_length,
             attention_backend=self.args.attention_backend,
@@ -140,6 +143,16 @@ class Eagle3Trainer(Trainer):
             loss_type=getattr(self.args, "loss_type", "forward_kl"),
             lk_eta=getattr(self.args, "lk_eta", 3.0),
         )
+        if num_anchors:
+            eagle3_model = AnchoredEagle3Model(
+                num_anchors=num_anchors, anchor_max_gap=anchor_max_gap, **model_kwargs
+            )
+            logger.info(
+                f"[Rank {self.dp_rank}] Anchored Eagle3: {num_anchors} anchors per sample "
+                f"(max gap {anchor_max_gap})"
+            )
+        else:
+            eagle3_model = Eagle3Model(**model_kwargs)
 
         full_state = eagle3_model.state_dict() if dist.get_rank() == 0 else {}
 


### PR DESCRIPTION
Adds DFlash style `training.eagle3_num_anchors`: the TTT unroll is evaluated at N sampled anchor positions per sample instead of at every supervised position, so each depth costs O(N) rather than O(sequence length). Off by default; the dense Eagle3 path is untouched.

**Why:** Cheaper and uniform length-sequence training. Also a long sequence can dominate the loss heavily, therefore anchor sampling ensures each sample contributes roughly equally, removing the bias for model to lean towards longer samples.

## How it works

Traditionally, EAGLE-3 trains with TTT rollout on every loss enabled token. The KV cache structure is shown below. This is expensive in terms of memory and runtime, especially for longer sequences.

<img width="1217" height="456" alt="image" src="https://github.com/user-attachments/assets/19f2bbbb-c8a6-45c2-9ce7-d29e8fc9122d" />

DFlash has a different training method, it randomly samples "anchor tokens" and predicts N block continuations from each token. It achieves this by sorting each anchor token and create a bidirectional attention mask for each block prediction. This technique helps DFlash train stabily on longer sequences, since anchor token count doesn't change for longer sequences. Faster and potentially more stable training.

<img width="1083" height="451" alt="Screenshot 2026-08-30 at 3 20 06 PM" src="https://github.com/user-attachments/assets/19ac591a-8a00-441e-bc59-489b98a12787" />

This PR combines both approaches, instead of doing TTT rollout on every token, we sample random anchor tokens to calculate loss from. Each token unsampled contributes through KV cache contributes anyway, so we don't need the full coverage to get similar results.

<img width="1136" height="281" alt="image" src="https://github.com/user-attachments/assets/0ce90619-ea47-4c1f-8699-f4c541dd32e2" />

This means we calculate loss from significantly tokens, however results already show this doesn't hurt meaningfully. Below is an image of loss calculation coverage. The dark color means contributes more to the loss, since there is weight decay on same TTT (Same as DFlash)

<img width="780" height="820" alt="image" src="https://github.com/user-attachments/assets/fdaf97be-f675-4158-8132-907cba8f1b29" />

Below is anchored, note that each token indirectly contributes via their KV cache anyway.

<img width="780" height="300" alt="image" src="https://github.com/user-attachments/assets/c1fcc357-361d-4dd8-ad80-e79b49e8b607" />

Since each token's weight is different, model can be trained for more epochs. In each epoch, data order will be random, so an un-seen token, or a seen but different TTT / weight token can contribute in the other epoch.

## Runtime

**Attention only (TTT=4, N=256, one GB300, ms / peak GB)**

| seq | dense TTT | anchored SDPA | anchored BlockMask | anchored score_mod |
|---|---|---|---|---|
| 4096 | 1.78 / 0.24 | 1.12 / 0.08 | **0.97 / 0.08** | 0.97 / 0.08 |
| 6144 | 3.82 / 0.44 | **1.10 / 0.12** | 1.38 / 0.15 | 1.39 / 0.11 |
| 16384 | 20.77 / 1.11 | **2.30 / 0.30** | 3.44 / 0.34 | 3.45 / 0.31 |
| 32768 | 75.95 / 2.06 | **4.24 / 0.59** | 6.73 / 0.61 | 6.75 / 0.57 |
| 131072 | 1134.53 / 7.89 | **15.88 / 2.33** | 26.43 / 2.22 | 26.45 / 2.19 |

Dense time and memory grows quadratically, anchored is roughly flat. SDPA does **not** cost more memory, since the mask is built with `H=1` and broadcast and SDPA tiles rather than materialising the score matrix.

**End-to-end training (Qwen3-8B, 20K open-perfectblend, 5 epochs)**

Open-perfectblend doesn't have very long rows, so the benefits are minimal, but still visible.

<img width="361" height="261" alt="image" src="https://github.com/user-attachments/assets/cd0f3506-87bf-4321-922e-69567007a6d1" />

DFlash is less data efficient, because predicted blocks are not overlapped with each other, so a token at position X is always treated as a token at (X mod block_size) position. Because position of a token also changes prediction hardness + loss weight, model doesn't see all tokens truly during training.

This has been validated by running EAGLE with non-overlapped anchors, the result was significantly worse than regular EAGLE, but it was better than DFlash and DFlash 2.

| Method | acc len | step/s | samples/s | opt steps | accum | state |
|---|---|---|---|---|---|---|
| DFlash | **0.39** | 5.1 | 10.1 | 12370 | 2 | completed |
| DFlash2 | **0.43** | 4.7 | 9.4 | 12370 | 2 | completed |
| EAGLE-3 (dense) | **0.78** | 17.4 | 17.4 | 24745 | 1 | completed |
| Anchored, scattered | **0.47** | 18.8 | 18.8 | 12163 | 1 | **died @ 12163** |
| Anchored, adjacent | **0.78** | 9.4 | 18.9 | 12370 | 2 | completed |

Also added block mask compilation for DFlash, which speeds up training by 10%,
```
block mask build is EAGER      →  9.26 samples/s
block mask build is COMPILED   → 10.24 samples/s   (1.106x)
```

## Multi-layer sweep (N=1024, TTT=4, one GB300, ms / peak GB)

| seq | | dense TTT | anchored SDPA | speedup |
|---|---|---|---|---|
| **4096** | L=1 | 1.79 / 0.24 | 1.24 / 0.17 | 1.44× |
| | L=2 | 3.53 / 0.24 | 2.84 / 0.17 | 1.24× |
| | L=5 | 8.78 / 0.24 | 6.99 / 0.17 | 1.26× |
| **6144** | L=1 | 3.82 / 0.44 | 1.44 / 0.23 | 2.65× |
| | L=2 | 7.63 / 0.44 | 4.51 / 0.29 | 1.69× |
| | L=5 | 18.99 / 0.44 | 11.15 / 0.29 | 1.70× |
| **32768** | L=1 | 75.89 / 2.06 | 5.37 / 1.02 | **14.1×** |
| | L=2 | 151.79 / 2.06 | 47.40 / 1.24 | 3.2× |
| | L=5 | 379.35 / 2.06 | 118.42 / 1.24 | 3.2× |

## MLA

| seq | dense TTT | anchored SDPA | speedup |
|---|---|---|---|
| 4096 | 2.89 / 0.92 | 1.21 / 0.43 | 2.4x |
| 6144 | 5.99 / 1.69 | 1.19 / 0.63 | 5.0x |
| 16384 | 34.27 / 4.20 | 2.17 / 1.60 | 15.8x |
| 32768 | 127.48 / 7.91 | 4.02 / 3.17 | **31.7x** |

Real end to end run timees.

| pblong10k, MLA draft, 16k seq | compute_time | data_time | step_time | samples/s |
|---|---|---|---|---|
| dense, 1 train / 3 infer | 0.1540 | 0.0374 | 0.1625 | 12.31 |
| anchored, 1 train / 3 infer | **0.1244** | 0.0299 | 0.1547 | 12.93 |

| data | median supervised | samples > N | GPU split | compute | end-to-end |
|---|---|---|---|---|---|
| pblong10k | 1401 | 100% | 1 train / 3 infer | **1.24x** | 1.05x |