### PR TITLE
perf: compile the BlockMask builder

### DIFF
--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 import torch._dynamo as dynamo
+from torch.nn.attention.flex_attention import create_block_mask
 from transformers import LlamaConfig
 
 import torchspec.models.draft.llama3_eagle as llama_mod
@@ -442,6 +443,37 @@ class TestFlashAttentionCachedPath(unittest.TestCase):
             llama_mod._std_flash_attn_forward = old_std_fwd
             llama_mod._std_flash_attn_backward = old_std_bwd
             llama_mod._std_flash_attn_mod = old_std_mod
+
+
+class TestCompiledBlockMask(unittest.TestCase):
+    """The builder is compiled for speed; it must not change the mask it produces.
+
+    DFlash rebuilds its BlockMask every step and the eager build dominates the attention
+    it saves, so compile_friendly_create_block_mask compiles create_block_mask. Inductor
+    cannot codegen it when the whole mask is a single block, which is why shapes at or
+    under one block stay eager.
+    """
+
+    @unittest.skipUnless(torch.cuda.is_available(), "create_block_mask needs CUDA")
+    def test_compiled_build_matches_eager(self):
+        q_len, kv_len = 1024, 2048
+        mask_mod = generate_eagle3_mask(Q_LEN=q_len, KV_LEN=kv_len)
+
+        compiled = compile_friendly_create_block_mask(mask_mod, 1, None, q_len, kv_len, "cuda")
+        eager = create_block_mask(mask_mod, 1, None, q_len, kv_len, "cuda")
+
+        torch.testing.assert_close(compiled.to_dense(), eager.to_dense())
+
+    @unittest.skipUnless(torch.cuda.is_available(), "create_block_mask needs CUDA")
+    def test_single_block_shape_still_builds(self):
+        """Q_LEN and KV_LEN both within one block: the eager fallback must be taken."""
+        q_len, kv_len = 64, 128
+        mask_mod = generate_eagle3_mask(Q_LEN=q_len, KV_LEN=kv_len)
+
+        built = compile_friendly_create_block_mask(mask_mod, 1, None, q_len, kv_len, "cuda")
+        eager = create_block_mask(mask_mod, 1, None, q_len, kv_len, "cuda")
+
+        torch.testing.assert_close(built.to_dense(), eager.to_dense())
 
 
 if __name__ == "__main__":

--- a/torchspec/models/ops/flex_attention.py
+++ b/torchspec/models/ops/flex_attention.py
@@ -95,6 +95,9 @@ def compile_friendly_flex_attention(
     )
 
 
+_compiled_create_block_mask = None
+
+
 def compile_friendly_create_block_mask(
     mask_mod,
     B,
@@ -104,12 +107,25 @@ def compile_friendly_create_block_mask(
     device,
     BLOCK_SIZE: "int | tuple[int, int]" = 128,
 ):
-    """Create block mask directly (no compilation wrapper).
+    """Create a BlockMask, compiling the builder when the shape allows it.
 
-    Matches SpecForge behavior — create_block_mask is fast enough without
-    torch.compile, and compiling it adds overhead with torch 2.9.1.
+    DFlash rebuilds its BlockMask every step, and building it eagerly dominates the
+    attention it saves: at ctx 4096 the eager build is 5.4ms against ~1.5ms for the
+    attention itself. Compiling the builder is the documented way to speed it up.
+
+    torch.compile of ``create_block_mask`` fails when the whole mask fits in one block
+    (Q_LEN <= 128 and KV_LEN <= 128), so that case stays eager. DFlash is far above it —
+    Q_LEN is ``num_anchors * block_size``.
     """
-    return create_block_mask(
+    global _compiled_create_block_mask
+
+    if Q_LEN <= 128 and KV_LEN <= 128:
+        return create_block_mask(mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE=BLOCK_SIZE)
+
+    if _compiled_create_block_mask is None:
+        _compiled_create_block_mask = torch.compile(create_block_mask, dynamic=True)
+
+    return _compiled_create_block_mask(
         mask_mod,
         B,
         H,


### PR DESCRIPTION
`create_block_mask` was running uncompiled: **35.3 ms vs 3.7 ms** for a 7-depth unroll. `compile_friendly_create_block_mask` now compiles, gated to skip the single-block case (`Q_LEN <= 128 and KV_LEN <= 128`) where inductor cannot codegen, with an eager fallback.

The helper's docstring claimed the opposite — *"create_block_mask is fast enough without torch.compile, and compiling it adds overhead with torch 2.9.1"* — which is what sent me looking. For any path that rebuilds the mask **every step**, the eager build costs more than the attention it saves.

## Mask build cost (one GB300)

| DFlash config | eager | compiled | |
|---|---|---|---|
| 512 anchors x block 16, ctx 4096 | 5.39 ms | **1.72 ms** | 3.1x |
| 512 anchors x block 16, ctx 16384 | 5.60 ms | **3.25 ms** | 1.7x |
| 512 anchors x block 8, ctx 4096 | 5.60 ms | **0.69 ms** | 8.1x |

DFlash rebuilds this every step (`dflash.py:303`, cached only within a forward), so that is 0.7–3.7 ms/step recovered on every DFlash and DSpark run.

## End-to-end training

Qwen3-8B DFlash, 2k PerfectBlend rows, 1 epoch, accum=2, seed 42 — two runs differing **only** in this helper, post-warmup median (first 100 steps dropped):

| build | step/s | samples/s | |
|---|---|---|---|
| eager | 4.63 | 9.26 | |
| compiled | **5.12** | **10.24** | **1.11x** |

Each arm prints which path it took at startup (`block mask build is EAGER` / `COMPILED`), so the A/B is self-verifying rather than assumed.

## Tests

`test_compiled_build_matches_eager` asserts the compiled builder produces the same dense mask as the eager one; `test_single_block_shape_still_builds` covers the fallback shape.

## Notes

- Split out of #186 (anchored Eagle3), which no longer needs it — that path masks through `scaled_dot_product_attention` and builds no BlockMask.
- The earlier microbenchmark figure of 19.8 -> 2.1 ms overstated the win for DFlash specifically: DFlash's `Q_LEN = num_anchors * block_size = 8192` is far larger than the anchored `Q_LEN = 256`, so eager construction is relatively less dominant there.
