### PR TITLE
perf(mooncake): overlap hidden-state publication

### DIFF
--- a/patches/vllm/nightly-7794b1e08bf505ff28664515ffaaeeec955ab796/vllm_pp_hidden_states.patch
+++ b/patches/vllm/nightly-7794b1e08bf505ff28664515ffaaeeec955ab796/vllm_pp_hidden_states.patch
@@ -112,7 +112,7 @@ diff --git a/vllm/model_executor/models/qwen2.py b/vllm/model_executor/models/qw
 +            return intermediate_tensors
  
          hidden_states, _ = self.norm(hidden_states, residual)
- 
+
 diff --git a/vllm/models/kimi_k3/nvidia/model.py b/vllm/models/kimi_k3/nvidia/model.py
 index 7efe92893..8f536e497 100644
 --- a/vllm/models/kimi_k3/nvidia/model.py
@@ -424,7 +424,7 @@ index d500b6720..78a7128c4 100644
              else:
                  # Rare case.
                  assert not self.is_pooling_model
-@@ -4542,11 +4568,23 @@ class GPUModelRunner(
+@@ -4542,11 +4568,21 @@ class GPUModelRunner(
          self, grammar_output: "GrammarOutput | None"
      ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
          if self.execute_model_state is None:
@@ -444,12 +444,10 @@ index d500b6720..78a7128c4 100644
 +                and not get_pp_group().is_last_rank
 +            ):
                  self._pp_receive_prev_sampled_token_ids_to_input_batch()
-+            if extract_hidden_states and get_pp_group().world_size > 1:
-+                get_pp_group().barrier()
              # In case of PP with kv transfer, we need to pass through the
              # kv_connector_output
              return ModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
-@@ -4567,6 +4605,40 @@ class GPUModelRunner(
+@@ -4567,6 +4603,38 @@ class GPUModelRunner(
          # Clear ephemeral state.
          self.execute_model_state = None
  
@@ -464,8 +462,6 @@ index d500b6720..78a7128c4 100644
 +                "sampling, token proposal, and decode"
 +            )
 +            self.finalize_kv_connector()
-+            if get_pp_group().world_size > 1:
-+                get_pp_group().barrier()
 +            self.eplb_step()
 +
 +            kv_connector_output = self.kv_connector_output
@@ -490,15 +486,3 @@ index d500b6720..78a7128c4 100644
          # Apply structured output bitmasks if present.
          if grammar_output is not None:
              apply_grammar_bitmask(
-@@ -4743,6 +4815,11 @@ class GPUModelRunner(
-         # draft model to also save its KV cache.
-         if spec_config is not None:
-             self.finalize_kv_connector()
-+            if (
-+                spec_config.uses_extract_hidden_states()
-+                and get_pp_group().world_size > 1
-+            ):
-+                get_pp_group().barrier()
- 
-         with record_function_or_nullcontext("gpu_model_runner: eplb"):
-             self.eplb_step()

--- a/patches/vllm/nightly-e9d1398d9edfd90fcc1cf783805240e3effec013/vllm_pp_hidden_states.patch
+++ b/patches/vllm/nightly-e9d1398d9edfd90fcc1cf783805240e3effec013/vllm_pp_hidden_states.patch
@@ -2,8 +2,8 @@ TorchSpec PP hidden-state extraction patch for
 vllm/vllm-openai:nightly-e9d1398d9edfd90fcc1cf783805240e3effec013.
 
 The patch is forward-ported against vLLM project commit
-e9d1398d9edfd90fcc1cf783805240e3effec013 and keeps PP extraction-only
-execution separate from the later async-publication and barrier-overlap work.
+e9d1398d9edfd90fcc1cf783805240e3effec013 and includes asynchronous
+publication and pipeline-overlap support.
 diff --git a/vllm/model_executor/models/extract_hidden_states.py b/vllm/model_executor/models/extract_hidden_states.py
 index d94db2c692da2059fe1efa97352dd5fec8908b21..6fc5f892dda539811158c130fa47653aee752904 100644
 --- a/vllm/model_executor/models/extract_hidden_states.py
@@ -353,7 +353,7 @@ index 6325c1bf5daaf61c81ac501889efc74797849ea1..c8aa9b9f79a30986c81b1480e50711e0
      def _get_slot_mapping(
          self,
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 4ef7f5860a5fd3ff370cedad754e691e97320b2c..a359b7f89d100e9b49b70df7f1599e0f7e303473 100644
+index 4ef7f5860..0a9fa2d6b 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -487,7 +487,7 @@ class ExecuteModelState(NamedTuple):
@@ -431,7 +431,7 @@ index 4ef7f5860a5fd3ff370cedad754e691e97320b2c..a359b7f89d100e9b49b70df7f1599e0f
              else:
                  # Rare case.
                  assert not self.is_pooling_model
-@@ -4664,11 +4690,23 @@ class GPUModelRunner(
+@@ -4664,10 +4690,20 @@ class GPUModelRunner(
          self, grammar_output: "GrammarOutput | None"
      ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
          if self.execute_model_state is None:
@@ -451,12 +451,9 @@ index 4ef7f5860a5fd3ff370cedad754e691e97320b2c..a359b7f89d100e9b49b70df7f1599e0f
 +                and not get_pp_group().is_last_rank
 +            ):
                  self._pp_receive_prev_sampled_token_ids_to_input_batch()
-+            if extract_hidden_states and get_pp_group().world_size > 1:
-+                get_pp_group().barrier()
              # In case of PP with kv transfer, we need to pass through the
              # kv_connector_output
-             return ModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
-@@ -4689,6 +4727,40 @@ class GPUModelRunner(
+@@ -4689,6 +4725,38 @@ class GPUModelRunner(
          # Clear ephemeral state.
          self.execute_model_state = None
  
@@ -471,8 +468,6 @@ index 4ef7f5860a5fd3ff370cedad754e691e97320b2c..a359b7f89d100e9b49b70df7f1599e0f
 +                "sampling, token proposal, and decode"
 +            )
 +            self.finalize_kv_connector()
-+            if get_pp_group().world_size > 1:
-+                get_pp_group().barrier()
 +            self.eplb_step()
 +
 +            kv_connector_output = self.kv_connector_output
@@ -497,15 +492,3 @@ index 4ef7f5860a5fd3ff370cedad754e691e97320b2c..a359b7f89d100e9b49b70df7f1599e0f
          # Apply structured output bitmasks if present.
          if grammar_output is not None:
              apply_grammar_bitmask(
-@@ -4866,6 +4938,11 @@ class GPUModelRunner(
-         # draft model to also save its KV cache.
-         if spec_config is not None:
-             self.finalize_kv_connector()
-+            if (
-+                spec_config.uses_extract_hidden_states()
-+                and get_pp_group().world_size > 1
-+            ):
-+                get_pp_group().barrier()
- 
-         with record_function_or_nullcontext("gpu_model_runner: eplb"):
-             self.eplb_step()

--- a/tests/test_mooncake_async_publish.py
+++ b/tests/test_mooncake_async_publish.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 LightSeek Foundation
+# MIT License
+
+"""Inference-side contract for asynchronous Mooncake publication."""
+
+import sys
+from concurrent.futures import Future
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from torchspec.config.mooncake_config import MooncakeConfig
+from torchspec.inference.engine.mooncake_hidden_states_connector import (
+    MooncakeHiddenStatesConnector,
+)
+from torchspec.transfer.mooncake.buffers import AsyncPutManager, HostBuffer
+from torchspec.transfer.mooncake.eagle_store import EagleMooncakeStore
+from torchspec.transfer.mooncake.store import MooncakeHiddenStateStore
+
+
+class _ConcreteStore(MooncakeHiddenStateStore):
+    pass
+
+
+def _make_store(raw_store, **config_kwargs):
+    store = _ConcreteStore(MooncakeConfig(**config_kwargs))
+    store._store = raw_store
+    store._initialized = True
+    store._init_event.set()
+    return store
+
+
+def test_connector_wait_for_save_checks_errors_without_flush():
+    connector = object.__new__(MooncakeHiddenStatesConnector)
+    connector._mooncake_store = MagicMock()
+
+    connector.wait_for_save()
+
+    connector._mooncake_store.check_async_errors.assert_called_once_with()
+    connector._mooncake_store.flush.assert_not_called()
+
+
+def test_eagle_raw_put_validates_then_delegates():
+    store = object.__new__(EagleMooncakeStore)
+    store._ensure_initialized = MagicMock()
+    store._put_raw_tensors = MagicMock()
+    keys = ["req_layer2_hs", "req_layer2_ids"]
+    tensors = [MagicMock(), MagicMock()]
+
+    store.put_raw_tensors(keys, tensors)
+
+    store._ensure_initialized.assert_called_once_with()
+    store._put_raw_tensors.assert_called_once_with(keys, tensors)
+
+
+def test_async_error_check_does_not_wait_for_running_put():
+    manager = AsyncPutManager(MagicMock(), max_workers=1)
+    pending = Future()
+    manager._in_flight[123] = pending
+
+    manager.check_errors()
+
+    assert manager._in_flight[123] is pending
+    pending.set_result(None)
+    manager.shutdown()
+
+
+def test_async_error_check_surfaces_completed_failure():
+    manager = AsyncPutManager(MagicMock(), max_workers=1)
+    failed = Future()
+    failed.set_exception(RuntimeError("put failed"))
+    manager._in_flight[123] = failed
+
+    with pytest.raises(RuntimeError, match="put failed"):
+        manager.check_errors()
+
+    assert 123 not in manager._in_flight
+    manager.shutdown()
+
+
+def test_store_check_async_errors_delegates_without_drain():
+    store = _make_store(MagicMock())
+    store._async_put_manager = MagicMock()
+
+    store.check_async_errors()
+
+    store._async_put_manager.check_errors.assert_called_once_with()
+    store._async_put_manager.drain.assert_not_called()
+
+
+def test_batch_exists_uses_single_metadata_census():
+    raw_store = MagicMock(spec=["batch_is_exist", "is_exist"])
+    raw_store.batch_is_exist.return_value = [1, 0, True]
+    store = _make_store(raw_store)
+
+    assert store.batch_exists(["a", "b", "c"]) == {
+        "a": True,
+        "b": False,
+        "c": True,
+    }
+    raw_store.batch_is_exist.assert_called_once_with(["a", "b", "c"])
+    raw_store.is_exist.assert_not_called()
+
+
+def test_wait_for_keys_retries_metadata_only_until_complete():
+    raw_store = MagicMock(spec=["batch_is_exist"])
+    raw_store.batch_is_exist.side_effect = [[1, 0], [1, 1]]
+    store = _make_store(raw_store)
+
+    with patch("torchspec.transfer.mooncake.store.time.sleep") as sleep:
+        store.wait_for_keys(["layer0", "layer1"], timeout=1.0, poll_interval=0.01)
+
+    assert raw_store.batch_is_exist.call_count == 2
+    sleep.assert_called_once_with(0.01)
+
+
+def test_wait_for_keys_timeout_names_every_missing_fragment():
+    raw_store = MagicMock(spec=["batch_is_exist"])
+    raw_store.batch_is_exist.return_value = [1, 0, 0]
+    store = _make_store(raw_store)
+
+    with patch(
+        "torchspec.transfer.mooncake.store.time.monotonic",
+        side_effect=[10.0, 10.2],
+    ):
+        with pytest.raises(TimeoutError, match=r"missing: layer1, layer2"):
+            store.wait_for_keys(
+                ["layer0", "layer1", "layer2"],
+                timeout=0.1,
+                poll_interval=0.01,
+            )
+
+
+def test_eagle_get_waits_for_all_keys_before_moving_bytes():
+    trace = []
+    store = object.__new__(EagleMooncakeStore)
+    store._initialized = True
+    store._init_event = MagicMock()
+    store._init_event.is_set.return_value = True
+    store._gpu_direct_available = False
+    store._gpu_receive_buffer = None
+    store.wait_for_keys = MagicMock(side_effect=lambda keys: trace.append(("wait", keys)))
+    store._get_tensors_via_host_buffer = MagicMock(
+        side_effect=lambda keys, specs, device: (
+            trace.append(("get", keys)) or {"hidden_states": "hs", "input_ids": "ids"}
+        )
+    )
+
+    target_module = ModuleType("torchspec.models.target.eagle3_target_model")
+
+    class Eagle3TargetOutput:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    target_module.Eagle3TargetOutput = Eagle3TargetOutput
+    with patch.dict(
+        sys.modules,
+        {"torchspec.models.target.eagle3_target_model": target_module},
+    ):
+        store.get(
+            "req",
+            shapes={"hidden_states": (2, 3), "input_ids": (2,)},
+            dtypes={},
+            device="cuda",
+        )
+
+    assert trace == [
+        ("wait", ["req_hs", "req_ids"]),
+        ("get", ["req_hs", "req_ids"]),
+    ]
+
+
+def test_host_buffer_copy_is_non_blocking():
+    copied = {}
+
+    class View:
+        def copy_(self, source, **kwargs):
+            copied["source"] = source
+            copied.update(kwargs)
+
+    class Storage:
+        def __getitem__(self, item):
+            return View()
+
+    class Tensor:
+        def contiguous(self):
+            return self
+
+        def numel(self):
+            return 4
+
+        def element_size(self):
+            return 2
+
+        def view(self, *args):
+            return self
+
+    buffer = object.__new__(HostBuffer)
+    buffer.size = 32
+    buffer._tensor = Storage()
+
+    assert buffer.copy_from_tensor(Tensor(), offset=4) == 8
+    assert copied["non_blocking"] is True

--- a/tests/test_mooncake_connector_finished.py
+++ b/tests/test_mooncake_connector_finished.py
@@ -68,30 +68,87 @@ def test_save_kv_layer_is_noop_for_latest_vllm_lifecycle():
     connector.save_kv_layer("cache_only_layers.93", MagicMock(), MagicMock())
 
 
-def test_publish_pending_save_writes_only_pipeline_local_layers(monkeypatch):
+def test_publish_pending_saves_pack_pipeline_fragments(monkeypatch):
     connector = MooncakeHiddenStatesConnector.__new__(MooncakeHiddenStatesConnector)
     connector._block_size = 3
-    connector._kv_cache = torch.arange(2 * 4 * 3 * 2, dtype=torch.bfloat16).view(2, 4, 3, 2)
+    connector._kv_cache = torch.arange(2 * 4 * 3 * 2, dtype=torch.float16).view(2, 4, 3, 2)
     connector._pp_size = 2
     connector._layer_ids = [2, 46, 90, 93]
     connector._mooncake_store = MagicMock()
+    connector._mooncake_store.config.host_buffer_size = 1024
     monkeypatch.setattr(connector, "_ensure_mooncake_store", lambda: True)
     monkeypatch.setattr(connector, "_local_layer_positions", lambda: [0, 1])
     pending = _PendingSave("req", torch.tensor([10, 20, 30]), [1])
 
-    connector._publish_pending_save(pending)
+    connector._publish_pending_saves([pending])
 
-    assert [call.kwargs["key"] for call in connector._mooncake_store.put.call_args_list] == [
-        "req_layer2",
-        "req_layer46",
+    connector._mooncake_store.put_raw_tensors.assert_called_once()
+    keys, tensors = connector._mooncake_store.put_raw_tensors.call_args.args
+    assert keys == [
+        "req_layer2_hs",
+        "req_layer2_ids",
+        "req_layer46_hs",
+        "req_layer46_ids",
     ]
-    first = connector._mooncake_store.put.call_args_list[0].kwargs
-    assert first["hidden_states"].shape == (3, 2)
-    assert first["input_ids"].tolist() == [10, 20, 30]
-    assert first["last_hidden_states"] is None
+    assert tensors[0].shape == (3, 2)
+    assert tensors[0].dtype == torch.bfloat16
+    assert tensors[1].tolist() == [10, 20, 30]
+    assert tensors[2].dtype == torch.bfloat16
 
 
-def test_get_finished_flushes_before_pipeline_barrier(monkeypatch):
+def test_pending_save_tensors_normalizes_tp_hidden_states():
+    connector = MooncakeHiddenStatesConnector.__new__(MooncakeHiddenStatesConnector)
+    connector._block_size = 3
+    connector._kv_cache = torch.arange(2 * 4 * 3 * 2, dtype=torch.float16).view(2, 4, 3, 2)
+    connector._pp_size = 1
+    connector._num_training_layers = 3
+    connector._hidden_size = 2
+    pending = _PendingSave("req", torch.tensor([10, 20, 30]), [1])
+
+    tensors = connector._pending_save_tensors(pending, [])
+
+    assert [key for key, _ in tensors] == ["req_hs", "req_ids", "req_lhs"]
+    assert tensors[0][1].dtype == torch.bfloat16
+    assert tensors[1][1].dtype == torch.int64
+    assert tensors[2][1].dtype == torch.bfloat16
+
+
+def test_publish_pending_saves_splits_at_host_buffer_capacity(monkeypatch):
+    connector = MooncakeHiddenStatesConnector.__new__(MooncakeHiddenStatesConnector)
+    connector._block_size = 3
+    connector._kv_cache = torch.randn(4, 4, 3, 2, dtype=torch.bfloat16)
+    connector._pp_size = 2
+    connector._layer_ids = [2, 46, 90, 93]
+    connector._mooncake_store = MagicMock()
+    connector._mooncake_store.config.host_buffer_size = 60
+    monkeypatch.setattr(connector, "_ensure_mooncake_store", lambda: True)
+    monkeypatch.setattr(connector, "_local_layer_positions", lambda: [0, 1])
+    pending = [
+        _PendingSave("req0", torch.tensor([1, 2, 3]), [1]),
+        _PendingSave("req1", torch.tensor([4, 5, 6]), [2]),
+    ]
+
+    connector._publish_pending_saves(pending)
+
+    calls = connector._mooncake_store.put_raw_tensors.call_args_list
+    assert len(calls) == 3
+    assert calls[0].args[0] == [
+        "req0_layer2_hs",
+        "req0_layer2_ids",
+        "req0_layer46_hs",
+    ]
+    assert calls[1].args[0] == [
+        "req0_layer46_ids",
+        "req1_layer2_hs",
+        "req1_layer2_ids",
+    ]
+    assert calls[2].args[0] == [
+        "req1_layer46_hs",
+        "req1_layer46_ids",
+    ]
+
+
+def test_get_finished_checks_errors_without_drain_before_pipeline_barrier(monkeypatch):
     connector = MooncakeHiddenStatesConnector.__new__(MooncakeHiddenStatesConnector)
     connector._pp_size = 2
     connector._mooncake_store = MagicMock()
@@ -100,15 +157,16 @@ def test_get_finished_flushes_before_pipeline_barrier(monkeypatch):
     monkeypatch.setattr(connector, "has_connector_metadata", lambda: True)
     monkeypatch.setattr(connector, "_get_connector_metadata", lambda: metadata)
     events = []
-    monkeypatch.setattr(connector, "_publish_pending_save", lambda item: events.append("put"))
-    connector._mooncake_store.flush.side_effect = lambda: events.append("flush")
+    monkeypatch.setattr(connector, "_publish_pending_saves", lambda items: events.append("put"))
+    connector._mooncake_store.check_async_errors.side_effect = lambda: events.append("check")
     pp_group = MagicMock()
     pp_group.barrier.side_effect = lambda: events.append("barrier")
     monkeypatch.setattr("vllm.distributed.get_pp_group", lambda: pp_group)
 
     finished_sending, finished_receiving = connector.get_finished(set())
 
-    assert events == ["put", "flush", "barrier"]
+    assert events == ["put", "check", "barrier"]
+    connector._mooncake_store.flush.assert_not_called()
     assert finished_sending == {"req"}
     assert finished_receiving is None
 
@@ -123,7 +181,7 @@ def test_get_finished_reaches_barrier_then_propagates_put_failure(monkeypatch):
     monkeypatch.setattr(connector, "_get_connector_metadata", lambda: metadata)
     monkeypatch.setattr(
         connector,
-        "_publish_pending_save",
+        "_publish_pending_saves",
         MagicMock(side_effect=RuntimeError("put failed")),
     )
     pp_group = MagicMock()
@@ -132,6 +190,7 @@ def test_get_finished_reaches_barrier_then_propagates_put_failure(monkeypatch):
     with pytest.raises(RuntimeError, match="put failed"):
         connector.get_finished(set())
 
+    connector._mooncake_store.check_async_errors.assert_not_called()
     connector._mooncake_store.flush.assert_not_called()
     pp_group.barrier.assert_called_once_with()
 

--- a/torchspec/inference/engine/mooncake_hidden_states_connector.py
+++ b/torchspec/inference/engine/mooncake_hidden_states_connector.py
@@ -305,7 +305,10 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
 
     def wait_for_save(self):
         if self._mooncake_store is not None:
-            self._mooncake_store.flush()
+            # Do not serialize the engine step behind the RDMA write.  Readers
+            # wait for the published keys before moving bytes; here we only
+            # surface failures from puts that have already completed.
+            self._mooncake_store.check_async_errors()
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         from vllm.model_executor.models.extract_hidden_states import (
@@ -337,12 +340,11 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         # Per-layer metadata is not guaranteed to contain a complete request.
         pass
 
-    def _publish_pending_save(self, pending: _PendingSave) -> None:
-        local_positions = self._local_layer_positions()
-        if self._pp_size > 1 and not local_positions:
-            return
-        if not self._ensure_mooncake_store():
-            return
+    def _pending_save_tensors(
+        self,
+        pending: _PendingSave,
+        local_positions: list[int],
+    ) -> list[tuple[str, torch.Tensor]]:
         assert self._kv_cache is not None
 
         num_tokens = pending.token_ids.shape[0]
@@ -363,30 +365,65 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             slot_mapping,
             num_tokens,
         )
+        if hidden_states_3d.dtype != torch.bfloat16:
+            hidden_states_3d = hidden_states_3d.to(torch.bfloat16)
         input_ids = pending.token_ids.to(hidden_states_3d.device)
         mooncake_key = _sanitize_mooncake_key(pending.req_id)
 
         if self._pp_size == 1:
             all_hidden = hidden_states_3d.reshape(num_tokens, -1)
             split_at = self._num_training_layers * self._hidden_size
-            self._mooncake_store.put(
-                key=mooncake_key,
-                hidden_states=all_hidden[:, :split_at],
-                input_ids=input_ids,
-                last_hidden_states=all_hidden[:, -self._hidden_size :],
-                target=None,
-            )
-            return
+            return [
+                (f"{mooncake_key}_hs", all_hidden[:, :split_at]),
+                (f"{mooncake_key}_ids", input_ids),
+                (f"{mooncake_key}_lhs", all_hidden[:, -self._hidden_size :]),
+            ]
 
+        tensors: list[tuple[str, torch.Tensor]] = []
         for position in local_positions:
-            layer_id = self._layer_ids[position]
-            self._mooncake_store.put(
-                key=f"{mooncake_key}_layer{layer_id}",
-                hidden_states=hidden_states_3d[:, position, :],
-                input_ids=input_ids,
-                last_hidden_states=None,
-                target=None,
+            layer_key = f"{mooncake_key}_layer{self._layer_ids[position]}"
+            tensors.extend(
+                [
+                    (f"{layer_key}_hs", hidden_states_3d[:, position, :]),
+                    (f"{layer_key}_ids", input_ids),
+                ]
             )
+        return tensors
+
+    def _publish_pending_saves(self, pending_saves: list[_PendingSave]) -> None:
+        local_positions = self._local_layer_positions()
+        if self._pp_size > 1 and not local_positions:
+            return
+        if not self._ensure_mooncake_store():
+            return
+        assert self._kv_cache is not None
+        capacity = int(self._mooncake_store.config.host_buffer_size)
+        keys: list[str] = []
+        tensors: list[torch.Tensor] = []
+        used_bytes = 0
+
+        def submit() -> None:
+            nonlocal keys, tensors, used_bytes
+            if keys:
+                self._mooncake_store.put_raw_tensors(keys, tensors)
+            keys = []
+            tensors = []
+            used_bytes = 0
+
+        for pending in pending_saves:
+            for key, tensor in self._pending_save_tensors(pending, local_positions):
+                tensor_bytes = tensor.numel() * tensor.element_size()
+                if tensor_bytes > capacity:
+                    raise RuntimeError(
+                        f"Mooncake tensor {key} needs {tensor_bytes} bytes, "
+                        f"host buffer has {capacity}"
+                    )
+                if keys and used_bytes + tensor_bytes > capacity:
+                    submit()
+                keys.append(key)
+                tensors.append(tensor)
+                used_bytes += tensor_bytes
+        submit()
 
     def get_finished(
         self,
@@ -404,12 +441,14 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
 
         local_error: BaseException | None = None
         try:
-            for pending in pending_saves:
-                self._publish_pending_save(pending)
+            self._publish_pending_saves(pending_saves)
             if self._mooncake_store is not None:
-                # Correctness-first completion: do not release cache blocks or
-                # report the request sent until every local PUT has completed.
-                self._mooncake_store.flush()
+                # The cache gather above creates independent GPU tensors. The
+                # store records them on its DtoH stream, so hidden-cache blocks
+                # can be released after scheduling while PUTs finish in the
+                # background. Surface any already-completed failure without
+                # draining the async manager; readers wait for every key.
+                self._mooncake_store.check_async_errors()
         except BaseException as exc:
             local_error = exc
 

--- a/torchspec/transfer/mooncake/buffers.py
+++ b/torchspec/transfer/mooncake/buffers.py
@@ -61,7 +61,10 @@ class HostBuffer:
 
         # PyTorch .copy_() handles CUDA→pinned-CPU directly in one DMA.
         # No need for .cpu() which would create an intermediate unpinned copy.
-        host_view.copy_(tensor.view(torch.uint8).view(-1))
+        # The destination is pinned, so CUDA sources can enqueue the DtoH copy
+        # on the caller's copy stream.  AsyncPutManager waits on the recorded
+        # copy_done event before handing the buffer to Mooncake.
+        host_view.copy_(tensor.view(torch.uint8).view(-1), non_blocking=True)
 
         return nbytes
 
@@ -136,6 +139,24 @@ class AsyncPutManager:
             err = self._last_error
             self._last_error = None
             raise err
+
+    def check_errors(self) -> None:
+        """Surface completed async failures without waiting for active puts.
+
+        Successful completed futures are retired here as well, which makes
+        their host buffers immediately reusable.  Futures that are still
+        running remain in ``_in_flight`` and this method returns immediately.
+        """
+        self.check_last_error()
+        for buffer_ptr, future in list(self._in_flight.items()):
+            if not future.done():
+                continue
+            self._in_flight.pop(buffer_ptr, None)
+            try:
+                future.result()
+            except Exception as exc:
+                self._last_error = exc
+                self.check_last_error()
 
     def wait_for_buffer(self, buffer_ptr: int) -> None:
         """Block until the in-flight transfer using *buffer_ptr* finishes.

--- a/torchspec/transfer/mooncake/eagle_store.py
+++ b/torchspec/transfer/mooncake/eagle_store.py
@@ -68,6 +68,21 @@ class EagleMooncakeStore(MooncakeHiddenStateStore):
 
     TENSOR_SUFFIXES = ["_hs", "_tgt", "_ids", "_lhs"]
 
+    def put_raw_tensors(self, keys: List[str], tensors: List[torch.Tensor]) -> None:
+        """Publish an already-normalized group of tensors in one batch.
+
+        The vLLM completed-request connector uses this to pack fragments from
+        multiple requests into each registered host buffer. This avoids one
+        serialized ``batch_put_from`` call per layer while retaining the same
+        per-layer Mooncake keys consumed by ``MooncakeDataset``.
+        """
+        self._ensure_initialized()
+        if not keys or len(keys) != len(tensors):
+            raise ValueError(
+                f"Expected equal non-empty keys/tensors, got {len(keys)}/{len(tensors)}"
+            )
+        self._put_raw_tensors(keys, tensors)
+
     def _put_raw_tensors(self, keys: List[str], tensors: List[torch.Tensor]) -> None:
         if self._gpu_direct_available and self._gpu_send_buffer is not None:
             buf = self._gpu_send_buffer
@@ -385,6 +400,12 @@ class EagleMooncakeStore(MooncakeHiddenStateStore):
                     dtypes.get("hidden_states", HIDDEN_STATES_STORAGE_DTYPE),
                 )
             )
+
+        # Publication is asynchronous on inference workers.  Wait for a
+        # complete metadata census before attempting either byte-transfer
+        # path; this also gives GPUDirect the retry/fail-closed behavior that
+        # previously existed only in the host-buffer fallback.
+        self.wait_for_keys(keys)
 
         tensor_map = None
         if self._gpu_direct_available and self._gpu_receive_buffer is not None:

--- a/torchspec/transfer/mooncake/store.py
+++ b/torchspec/transfer/mooncake/store.py
@@ -19,8 +19,9 @@
 # SOFTWARE.
 
 import threading
+import time
 from abc import ABC
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 import torch
 from mooncake.store import MooncakeDistributedStore
@@ -241,6 +242,77 @@ class MooncakeHiddenStateStore(ABC):
             return result == 1
         except Exception:
             return False
+
+    def batch_exists(self, keys: Sequence[str]) -> Dict[str, bool]:
+        """Return a metadata-only existence census for *keys*.
+
+        Newer Mooncake clients provide a one-RPC ``batch_is_exist`` API.  Keep
+        a per-key fallback for older supported clients, while preserving
+        errors so readers fail closed rather than mistaking a metadata failure
+        for a missing object.
+        """
+        self._ensure_initialized()
+        key_list = list(keys)
+        batch_is_exist = getattr(self._store, "batch_is_exist", None)
+        if callable(batch_is_exist):
+            results = list(batch_is_exist(key_list))
+            if len(results) != len(key_list):
+                raise RuntimeError(
+                    "Mooncake batch_is_exist returned "
+                    f"{len(results)} results for {len(key_list)} keys"
+                )
+        else:
+            results = [self._store.is_exist(key) for key in key_list]
+        return {key: result == 1 for key, result in zip(key_list, results)}
+
+    def wait_for_keys(
+        self,
+        keys: Sequence[str],
+        *,
+        timeout: Optional[float] = None,
+        poll_interval: Optional[float] = None,
+    ) -> None:
+        """Wait until every key is visible in Mooncake metadata.
+
+        This is deliberately called before either GPUDirect or host-buffer
+        byte movement.  A timeout reports the exact missing keys, which turns
+        an incomplete pipeline fragment into a fail-closed sample.
+        """
+        key_list = list(keys)
+        if not key_list:
+            return
+        if timeout is None:
+            timeout = self.config.get_retry_max_wait_seconds
+        if poll_interval is None:
+            poll_interval = self.config.get_retry_wait_seconds
+        poll_interval = max(float(poll_interval), 0.001)
+        timeout = float(timeout)
+        start = time.monotonic()
+        deadline = None if timeout <= 0 else start + timeout
+        last_missing = key_list
+
+        while True:
+            census = self.batch_exists(key_list)
+            last_missing = [key for key in key_list if not census[key]]
+            if not last_missing:
+                return
+            now = time.monotonic()
+            if deadline is not None and now >= deadline:
+                missing = ", ".join(last_missing)
+                raise TimeoutError(
+                    "Timed out waiting for Mooncake keys after "
+                    f"{now - start:.3f}s; missing: {missing}"
+                )
+            sleep_for = poll_interval
+            if deadline is not None:
+                sleep_for = min(sleep_for, max(deadline - now, 0.0))
+            time.sleep(sleep_for)
+
+    def check_async_errors(self) -> None:
+        """Surface completed background put failures without draining puts."""
+        self._ensure_initialized()
+        if self._async_put_manager is not None:
+            self._async_put_manager.check_errors()
 
     def _verify_force_delete(self) -> None:
         """Fail-fast if Mooncake doesn't support batch_remove(force=True).


### PR DESCRIPTION
## Summary

- keep inference steps from draining active Mooncake PUTs
- pack completed hidden-state fragments into registered host buffers and overlap D2H copies with background publication
- wait for all expected keys on the reader before moving bytes
- remove redundant pipeline barriers from the pinned vLLM extraction patches

## Validation

- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- Python compile checks on changed TorchSpec files
- both vLLM patch stacks apply with `patch --fuzz=0` against their pinned revisions
- patched vLLM Python modules compile successfully
- focused unit tests were added; local execution requires the full Torch/vLLM runtime and is left to CI

## Scope

This PR contains only the reusable connector, store, buffer, test, and vendored vLLM patch changes.