### PR TITLE
Support LK losses in anchored Eagle3

### DIFF
--- a/tests/test_anchored_eagle3.py
+++ b/tests/test_anchored_eagle3.py
@@ -150,19 +150,6 @@ class TestAnchoredModel(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "MRoPE"):
             AnchoredEagle3Model(draft_model=draft, length=T, attention_backend="flex_attention")
 
-    def test_rejects_unsupported_loss_types(self):
-        torch.manual_seed(0)
-        config = AutoDraftModelConfig.from_dict(dict(_EAGLE3))
-        draft = AutoEagle3DraftModel.from_config(config, torch_dtype=torch.float32)
-
-        with self.assertRaisesRegex(ValueError, "forward_kl"):
-            AnchoredEagle3Model(
-                draft_model=draft,
-                length=T,
-                attention_backend="flex_attention",
-                loss_type="lk_alpha",
-            )
-
     @unittest.skipUnless(torch.cuda.is_available(), "FlexAttention path needs CUDA")
     def test_mla_draft_with_far_fewer_anchors_than_positions(self):
         """The rotary table must span the sequence, not the anchor count.
@@ -254,10 +241,11 @@ class TestMatchesDense(unittest.TestCase):
 
     def test_per_depth_losses_match_dense(self):
         for name in ("llama", "mla"):
-            with self.subTest(draft=name):
-                self._assert_matches_dense(name)
+            for loss_type in ("forward_kl", "lk_alpha", "lk_lambda"):
+                with self.subTest(draft=name, loss_type=loss_type):
+                    self._assert_matches_dense(name, loss_type)
 
-    def _assert_matches_dense(self, draft_kind):
+    def _assert_matches_dense(self, draft_kind, loss_type="forward_kl"):
         torch.manual_seed(0)
         seq, hidden, supervised = 64, 64, 40
 
@@ -271,7 +259,8 @@ class TestMatchesDense(unittest.TestCase):
             input_ids=torch.randint(0, 128, (1, seq), device="cuda"),
             attention_mask=torch.ones(1, seq, dtype=torch.long, device="cuda"),
             target=PrecomputedTarget(
-                target_p_padded=torch.softmax(torch.randn(1, seq + T, 128, device="cuda"), dim=-1)
+                target_p_padded=torch.softmax(torch.randn(1, seq + T, 128, device="cuda"), dim=-1),
+                coverage_padded=torch.rand(1, seq + T, device="cuda").clamp_min(0.1),
             ),
             loss_mask=loss_mask,
             hidden_states=torch.randn(1, seq, hidden * 3, device="cuda"),
@@ -279,7 +268,7 @@ class TestMatchesDense(unittest.TestCase):
 
         # "sdpa" so the dense path builds the additive decoder mask its eager attention
         # needs; the anchored path builds its own mask either way.
-        shared = dict(draft_model=draft, length=T, attention_backend="sdpa")
+        shared = dict(draft_model=draft, length=T, attention_backend="sdpa", loss_type=loss_type)
         dense = Eagle3Model(**shared)
         anchored = AnchoredEagle3Model(num_anchors=seq, **shared)
 

--- a/torchspec/models/anchored_eagle3.py
+++ b/torchspec/models/anchored_eagle3.py
@@ -114,7 +114,14 @@ def _gather_target(
     loss reads the same either way with idx=0 and seq_length=num_anchors.
     """
     if isinstance(target, PrecomputedTarget):
-        return PrecomputedTarget(target_p_padded=_gather(target.target_p_padded, positions))
+        # coverage_padded travels with the gathered rows: the LK losses read the true
+        # target mass as target_p_padded * coverage_padded, and dropping it here would
+        # silently fall back to all-ones and overstate alpha under vocab pruning.
+        coverage = target.coverage_padded
+        return PrecomputedTarget(
+            target_p_padded=_gather(target.target_p_padded, positions),
+            coverage_padded=None if coverage is None else _gather(coverage, positions),
+        )
     return LazyTarget(
         hidden_states_padded=_gather(target.hidden_states_padded, positions),
         lm_head_weight=target.lm_head_weight,
@@ -140,10 +147,6 @@ class AnchoredEagle3Model(Eagle3Model):
                 "'mrope'). The dense path rotates through apply_multimodal_rotary_pos_emb "
                 "with the configured mrope_section, while the gathered-query path applies "
                 "standard rotary and would ignore the multidimensional position ids."
-            )
-        if self.loss_type != "forward_kl":
-            raise ValueError(
-                f"Anchored Eagle3 supports loss_type='forward_kl', got {self.loss_type!r}."
             )
         self.num_anchors = num_anchors
         self.anchor_max_gap = anchor_max_gap


### PR DESCRIPTION
`_gather_target` dropped `coverage_padded` when restricting a `PrecomputedTarget` to the anchor positions. The LK losses read the true target mass as `target_p_padded * coverage_padded`, so on the anchored path they would have fallen back to all-ones and overstated alpha wherever vocab pruning removed mass. Carrying it through makes them correct, so the `loss_type` guard is no longer needed — `Eagle3Model` already rejects anything outside the three supported types.

`test_per_depth_losses_match_dense` now runs over all three loss types with a non-uniform `coverage_padded`. Dropping the gather again fails the LK subtests (`lk_alpha`: dense 1.256 vs anchored 0.500) while `forward_kl`, which never reads coverage, still passes.

Tests: 67 passed on GPU (`tests/test_anchored_eagle3.py`, `tests/test_eagle3_loss.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)